### PR TITLE
Support OIDC UserInfo Endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.21.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -12,6 +12,9 @@
   <f:entry title="${%Authorization server url}" field="authorizationServerUrl">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%UserInfo server url}" field="userInfoServerUrl">
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%User name field}" field="userNameField">
     <f:textbox/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-userInfoServerUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-userInfoServerUrl.html
@@ -1,0 +1,3 @@
+<div>
+    Optional. userinfo url of the openid connect provider
+</div>


### PR DESCRIPTION
Claims are returned from the UserInfo endpoint (authenticate with accesstoken) in case of the authorization code flow. So we need an additional back channel call to the UserInfo endpoint to get f.e. profile and/or email claims (scope=openid profile email).