### PR TITLE
Add new setting to disable sslVerification - for testing purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 work/
 target/
 .idea/
+*.iml

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -33,4 +33,7 @@
   <f:entry title="${%Scopes}" field="scopes">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%Disable ssl verification}" field="disableSslVerification">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-disableSslVerification.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-disableSslVerification.html
@@ -1,0 +1,4 @@
+<div>
+    Cautious: This disables SSL Verification. This should just be used in Development Environments.
+    Use at your own risk.
+</div>


### PR DESCRIPTION
In order to test the plugin in a development/testing environment, we do need to avoid validation of Ssl certificates. This pull request provides a setting, to disable the ssl certificate validation.

BTW, an issue tracker would be nice.