### PR TITLE
Add groups at login if provided in the idToken as an array of strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,15 +38,16 @@
     </license>
   </licenses>
   <dependencies>
-    <dependency>
-      <groupId>com.google.oauth-client</groupId>
-      <artifactId>google-oauth-client</artifactId>
-      <version>1.22.0</version>
-    </dependency>
+    <!-- see build plugin unpack -->
+    <!--<dependency>-->
+      <!--<groupId>com.google.oauth-client</groupId>-->
+      <!--<artifactId>google-oauth-client</artifactId>-->
+      <!--<version>1.23.0</version>-->
+    <!--</dependency>-->
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.22.0</version>
+      <version>1.23.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -66,6 +67,34 @@
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.google.oauth-client</groupId>
+                  <artifactId>google-oauth-client</artifactId>
+                  <version>1.23.0</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                  <excludes>
+                    **/TokenResponse.class
+                  </excludes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,12 @@
   </licenses>
   <dependencies>
     <!-- see build plugin unpack -->
-    <!--<dependency>-->
-      <!--<groupId>com.google.oauth-client</groupId>-->
-      <!--<artifactId>google-oauth-client</artifactId>-->
-      <!--<version>1.23.0</version>-->
-    <!--</dependency>-->
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+      <version>1.23.0</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>

--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+    <Match>
+        <Package name="~com\.google\..*"/>
+    </Match>
+</FindBugsFilter>

--- a/src/main/java/com/google/api/client/auth/oauth2/TokenResponse.java
+++ b/src/main/java/com/google/api/client/auth/oauth2/TokenResponse.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.auth.oauth2;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonString;
+import com.google.api.client.util.Key;
+import com.google.api.client.util.Preconditions;
+
+/**
+ * OAuth 2.0 JSON model for a successful access token response as specified in <a
+ * href="http://tools.ietf.org/html/rfc6749#section-5.1">Successful Response</a>.
+ *
+ * <p>
+ * Implementation is not thread-safe.
+ * </p>
+ *
+ * @since 1.7
+ * @author Yaniv Inbar
+ */
+public class TokenResponse extends GenericJson {
+
+    /** Access token issued by the authorization server. */
+    @Key("access_token")
+    private String accessToken;
+
+    /**
+     * Token type (as specified in <a href="http://tools.ietf.org/html/rfc6749#section-7.1">Access
+     * Token Types</a>).
+     */
+    @Key("token_type")
+    private String tokenType;
+
+    /**
+     * Lifetime in seconds of the access token (for example 3600 for an hour) or {@code null} for
+     * none.
+     */
+    @Key("expires_in")
+    private Object expiresInSeconds;
+
+    /**
+     * Refresh token which can be used to obtain new access tokens using {@link RefreshTokenRequest}
+     * or {@code null} for none.
+     */
+    @Key("refresh_token")
+    private String refreshToken;
+
+    /**
+     * Scope of the access token as specified in <a
+     * href="http://tools.ietf.org/html/rfc6749#section-3.3">Access Token Scope</a> or {@code null}
+     * for none.
+     */
+    @Key
+    private String scope;
+
+    /** Returns the access token issued by the authorization server. */
+    public final String getAccessToken() {
+        return accessToken;
+    }
+
+    /**
+     * Sets the access token issued by the authorization server.
+     *
+     * <p>
+     * Overriding is only supported for the purpose of calling the super implementation and changing
+     * the return type, but nothing else.
+     * </p>
+     */
+    public TokenResponse setAccessToken(String accessToken) {
+        this.accessToken = Preconditions.checkNotNull(accessToken);
+        return this;
+    }
+
+    /**
+     * Returns the token type (as specified in <a
+     * href="http://tools.ietf.org/html/rfc6749#section-7.1">Access Token Types</a>).
+     */
+    public final String getTokenType() {
+        return tokenType;
+    }
+
+    /**
+     * Sets the token type (as specified in <a
+     * href="http://tools.ietf.org/html/rfc6749#section-7.1">Access Token Types</a>).
+     *
+     * <p>
+     * Overriding is only supported for the purpose of calling the super implementation and changing
+     * the return type, but nothing else.
+     * </p>
+     */
+    public TokenResponse setTokenType(String tokenType) {
+        this.tokenType = Preconditions.checkNotNull(tokenType);
+        return this;
+    }
+
+    /**
+     * Returns the lifetime in seconds of the access token (for example 3600 for an hour) or
+     * {@code null} for none.
+     */
+    public final Long getExpiresInSeconds() {
+        return Long.class.isInstance(expiresInSeconds) ? (Long) expiresInSeconds : Long.valueOf(String.valueOf(expiresInSeconds));
+    }
+
+    /**
+     * Sets the lifetime in seconds of the access token (for example 3600 for an hour) or {@code null}
+     * for none.
+     *
+     * <p>
+     * Overriding is only supported for the purpose of calling the super implementation and changing
+     * the return type, but nothing else.
+     * </p>
+     */
+    public TokenResponse setExpiresInSeconds(Long expiresInSeconds) {
+        this.expiresInSeconds = expiresInSeconds;
+        return this;
+    }
+
+    /**
+     * Returns the refresh token which can be used to obtain new access tokens using the same
+     * authorization grant or {@code null} for none.
+     */
+    public final String getRefreshToken() {
+        return refreshToken;
+    }
+
+    /**
+     * Sets the refresh token which can be used to obtain new access tokens using the same
+     * authorization grant or {@code null} for none.
+     *
+     * <p>
+     * Overriding is only supported for the purpose of calling the super implementation and changing
+     * the return type, but nothing else.
+     * </p>
+     */
+    public TokenResponse setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+        return this;
+    }
+
+    /**
+     * Returns the scope of the access token or {@code null} for none.
+     */
+    public final String getScope() {
+        return scope;
+    }
+
+    /**
+     * Sets the scope of the access token or {@code null} for none.
+     *
+     * <p>
+     * Overriding is only supported for the purpose of calling the super implementation and changing
+     * the return type, but nothing else.
+     * </p>
+     */
+    public TokenResponse setScope(String scope) {
+        this.scope = scope;
+        return this;
+    }
+
+    @Override
+    public TokenResponse set(String fieldName, Object value) {
+        return (TokenResponse) super.set(fieldName, value);
+    }
+
+    @Override
+    public TokenResponse clone() {
+        return (TokenResponse) super.clone();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -212,55 +212,6 @@ public class OicSecurityRealm extends SecurityRealm {
         return "securityRealm/commenceLogin";
     }
 
-    public static class OicUserDetails implements UserDetails {
-		private static final long serialVersionUID = 1L;
-
-		private final String userName;
-		private final GrantedAuthority[] grantedAuthorities;
-
-		protected OicUserDetails(String userName, GrantedAuthority[] grantedAuthorities) {
-			this.userName = userName;
-			this.grantedAuthorities = grantedAuthorities;
-		}
-		
-		@Override
-		public GrantedAuthority[] getAuthorities() {
-			LOGGER.fine("OicUserDetails.getAuthorities called, returning " + grantedAuthorities.length);
-			return this.grantedAuthorities;
-		}
-		
-		@Override
-		public String getPassword() {
-			// OpenID Connect => no passwords...
-			return null;
-		}
-
-		@Override
-		public String getUsername() {
-			return this.userName;
-		}
-
-		@Override
-		public boolean isAccountNonExpired() {
-			return true;
-		}
-
-		@Override
-		public boolean isAccountNonLocked() {
-			return true;
-		}
-
-		@Override
-		public boolean isCredentialsNonExpired() {
-			return true;
-		}
-
-		@Override
-		public boolean isEnabled() {
-			return true;
-		}
-    	
-    };
     /*
     * Acegi has this notion that first an {@link org.acegisecurity.Authentication} object is created
     * by collecting user information and then the act of authentication is done

--- a/src/main/java/org/jenkinsci/plugins/oic/OicUserDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicUserDetails.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.oic;
+
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.userdetails.UserDetails;
+
+import java.util.Arrays;
+
+public class OicUserDetails implements UserDetails {
+    private static final long serialVersionUID = 1L;
+
+    private final String userName;
+    private final GrantedAuthority[] grantedAuthorities;
+
+    public OicUserDetails(String userName, GrantedAuthority[] grantedAuthorities) {
+        this.userName = userName;
+        this.grantedAuthorities = Arrays.copyOf(grantedAuthorities, grantedAuthorities.length);
+    }
+
+    @Override
+    public GrantedAuthority[] getAuthorities() {
+        return Arrays.copyOf(grantedAuthorities, grantedAuthorities.length);
+    }
+
+    @Override
+    public String getPassword() {
+        // OpenID Connect => no passwords...
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.userName;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
@@ -1,0 +1,57 @@
+package org.jenkinsci.plugins.oic;
+
+import java.io.StringWriter;
+import java.util.logging.Logger;
+
+import org.acegisecurity.GrantedAuthority;
+
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+
+class OicUserProperty extends UserProperty {
+	private static final Logger LOGGER = Logger.getLogger(OicUserProperty.class.getName());
+    static class OicUserPropertyDescriptor extends UserPropertyDescriptor {
+
+		@Override
+		public UserProperty newInstance(User user) {
+			LOGGER.info("OicUserPropertyDescriptor.newInstance called, user:" + user);
+			return new OicUserProperty(user.getId(), new GrantedAuthority[0]);
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "OpenID Connect user property";
+		}
+    	
+    }
+	@Override
+	public UserPropertyDescriptor getDescriptor() {
+		return new OicUserPropertyDescriptor();
+	}
+	private GrantedAuthority[] authorities;
+	private String userName;
+
+	public OicUserProperty(String userName, GrantedAuthority[] authorities) {
+		this.userName = userName;
+		this.authorities = authorities;
+	}
+	public GrantedAuthority[] getAuthorities() {
+		return authorities;
+	}
+	
+	public String getAllGrantedAuthorities() {
+		StringWriter result = new StringWriter();
+		result.append("Number of GrantedAuthorities in OicUserProperty for " + userName + ": " + (authorities == null ? "null" : authorities.length));
+		if (authorities != null) {
+			for (GrantedAuthority a: authorities) {
+				result.append("<br>\nAuthority: " + a.getAuthority());
+			}
+		}
+		return result.toString();
+	}
+	
+	public String getUserName() {
+		return userName;
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
@@ -9,13 +9,14 @@ import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 
-class OicUserProperty extends UserProperty {
+public class OicUserProperty extends UserProperty {
 	private static final Logger LOGGER = Logger.getLogger(OicUserProperty.class.getName());
-    static class OicUserPropertyDescriptor extends UserPropertyDescriptor {
+
+    public static class Descriptor extends UserPropertyDescriptor {
 
 		@Override
 		public UserProperty newInstance(User user) {
-			LOGGER.info("OicUserPropertyDescriptor.newInstance called, user:" + user);
+			LOGGER.fine("OicUserPropertyDescriptor.newInstance called, user:" + user);
 			return new OicUserProperty(user.getId(), new GrantedAuthority[0]);
 		}
 
@@ -27,7 +28,7 @@ class OicUserProperty extends UserProperty {
     }
 	@Override
 	public UserPropertyDescriptor getDescriptor() {
-		return new OicUserPropertyDescriptor();
+		return new Descriptor();
 	}
 	private GrantedAuthority[] authorities;
 	private String userName;

--- a/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.oic;
 
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.logging.Logger;
 
 import org.acegisecurity.GrantedAuthority;
@@ -10,7 +11,6 @@ import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 
 public class OicUserProperty extends UserProperty {
-	private static final Logger LOGGER = Logger.getLogger(OicUserProperty.class.getName());
 
     public static class Descriptor extends UserPropertyDescriptor {
 
@@ -26,19 +26,18 @@ public class OicUserProperty extends UserProperty {
 		}
     	
     }
-	@Override
-	public UserPropertyDescriptor getDescriptor() {
-		return new Descriptor();
-	}
-	private GrantedAuthority[] authorities;
-	private String userName;
+
+	private static final Logger LOGGER = Logger.getLogger(OicUserProperty.class.getName());
+
+	private final GrantedAuthority[] authorities;
+	private final String userName;
 
 	public OicUserProperty(String userName, GrantedAuthority[] authorities) {
 		this.userName = userName;
-		this.authorities = authorities;
+		this.authorities = Arrays.copyOf(authorities, authorities.length);
 	}
 	public GrantedAuthority[] getAuthorities() {
-		return authorities;
+		return Arrays.copyOf(authorities, authorities.length);
 	}
 	
 	public String getAllGrantedAuthorities() {
@@ -54,5 +53,10 @@ public class OicUserProperty extends UserProperty {
 	
 	public String getUserName() {
 		return userName;
+	}
+
+	@Override
+	public UserPropertyDescriptor getDescriptor() {
+		return new Descriptor();
 	}
 }

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -33,6 +33,9 @@
   <f:entry title="${%Scopes}" field="scopes">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%Groups field name}" field="groupsFieldName">
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%Disable ssl verification}" field="disableSslVerification">
     <f:checkbox/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-groupsFieldName.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-groupsFieldName.html
@@ -1,0 +1,5 @@
+<div>
+    Not required. If the field exists in the token and is an array of strings, then each string is added as a group.
+    This allows groups based authorization in Jenkins. The SSO server will need to add the field with the list of groups in 
+    the token. For example in Keycloak, this can be done with a 'Group Membership' mapper in the configuration of the client.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/oic/TokenResponseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/TokenResponseTest.java
@@ -1,0 +1,56 @@
+package org.jenkinsci.plugins.oic;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.google.api.client.auth.oauth2.TokenResponse;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.json.JsonParser;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.common.base.Charsets;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * We'd like to be more permissive by allowing both long literals and Strigns containing to accepted
+ * See:
+ * https://github.com/jenkinsci/oic-auth-plugin/issues/10
+ * https://github.com/google/google-oauth-java-client/issues/62
+ */
+public class TokenResponseTest {
+
+    private static final String JSON_WITH_LONG_AS_STRING = "{\"access_token\":\"2YotnFZFEjr1zCsicMWpAA\","
+            + "\"token_type\":\"example\",\"expires_in\":\"3600\","
+            + "\"refresh_token\":\"tGzv3JOkF0XG5Qx2TlKWIA\","
+            + "\"example_parameter\":\"example_value\"}";
+
+    private static final String JSON_WITH_LONG_LITERAL = "{\"access_token\":\"2YotnFZFEjr1zCsicMWpAA\","
+            + "\"token_type\":\"example\",\"expires_in\":3600,"
+            + "\"refresh_token\":\"tGzv3JOkF0XG5Qx2TlKWIA\","
+            + "\"example_parameter\":\"example_value\"}";
+
+    @Test
+    public void parseLongLiteral() throws IOException {
+        JsonFactory jsonFactory = new JacksonFactory();
+        TokenResponse response = jsonFactory.fromString(JSON_WITH_LONG_LITERAL, TokenResponse.class);
+        assertEquals("2YotnFZFEjr1zCsicMWpAA", response.getAccessToken());
+        assertEquals("example", response.getTokenType());
+        assertEquals(3600L, response.getExpiresInSeconds().longValue());
+        assertEquals("tGzv3JOkF0XG5Qx2TlKWIA", response.getRefreshToken());
+        assertEquals("example_value", response.get("example_parameter"));
+    }
+
+    @Test
+    public void parseStringWithLong() throws IOException {
+        JsonFactory jsonFactory = new JacksonFactory();
+        TokenResponse response = jsonFactory.fromString(JSON_WITH_LONG_AS_STRING, TokenResponse.class);
+        assertEquals("2YotnFZFEjr1zCsicMWpAA", response.getAccessToken());
+        assertEquals("example", response.getTokenType());
+        assertEquals(3600L, response.getExpiresInSeconds().longValue());
+        assertEquals("tGzv3JOkF0XG5Qx2TlKWIA", response.getRefreshToken());
+        assertEquals("example_value", response.get("example_parameter"));
+    }
+}


### PR DESCRIPTION
These changes add a new setting 'groupsFieldName'. If it's set and the OpenID Connect server adds an array with that name containing group names in the ID token, then those groups are added as groups within Jenkins. This allows group based authorization in Jenkins.

Any comments welcome, this is +/- the first time I ever changed a Jenkins plugin.