### PR TITLE
Use the .well-known/openid-configuration autodiscovery endpoint

### DIFF
--- a/src/main/java/com/google/api/client/auth/oauth2/WellKnownOpenIDConfigurationResponse.java
+++ b/src/main/java/com/google/api/client/auth/oauth2/WellKnownOpenIDConfigurationResponse.java
@@ -1,0 +1,61 @@
+package com.google.api.client.auth.oauth2;
+
+import java.util.Map;
+import java.util.Set;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+/**
+ * OpenID Connect Discovery JSON.
+ * https://openid.net/specs/openid-connect-discovery-1_0.html
+ *
+ * @author Steve Arch
+ */
+public class WellKnownOpenIDConfigurationResponse extends GenericJson {
+    @Key("authorization_endpoint")
+    private String authorizationEndpoint;
+
+    @Key("token_endpoint")
+    private String tokenEndpoint;
+
+    @Key("userinfo_endpoint")
+    private String userinfoEndpoint;
+
+    @Key("jwks_uri")
+    private String jwksUri;
+
+    @Key("scopes_supported")
+    private Set<String> scopesSupported;
+
+    public String getAuthorizationEndpoint() {
+        return authorizationEndpoint;
+    }
+
+    public String getTokenEndpoint() {
+        return tokenEndpoint;
+    }
+
+    public String getUserinfoEndpoint() {
+        return userinfoEndpoint;
+    }
+
+    public String getJwksUri() {
+        return jwksUri;
+    }
+
+    public Set<String> getScopesSupported() {
+        return scopesSupported;
+    }
+
+    /**
+     * Mimicks {@link GenericJson#getUnknownKeys()}, but returning the map of known keys
+     * @return
+     */
+    public Map<String, Object> getKnownKeys() {
+        Map<String, Object> clone = this.clone();
+        for(String key : this.getUnknownKeys().keySet()) {
+            clone.remove(key);
+        }
+        return clone;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -178,7 +178,7 @@ public class OicSecurityRealm extends SecurityRealm {
         return this;
     }
 
-    private HttpTransport constructHttpTransport(boolean disableSslVerification) {
+    private static HttpTransport constructHttpTransport(boolean disableSslVerification) {
         NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
         builder.setConnectionFactory(new JenkinsAwareConnectionFactory());
 
@@ -629,14 +629,14 @@ public class OicSecurityRealm extends SecurityRealm {
             return FormValidation.ok();
         }
 
-        public FormValidation doCheckWellKnownOpenIDConfigurationUrl(@QueryParameter String wellKnownOpenIDConfigurationUrl) {
+        public FormValidation doCheckWellKnownOpenIDConfigurationUrl(@QueryParameter String wellKnownOpenIDConfigurationUrl, @QueryParameter boolean disableSslVerification) {
             try {
                 URL url = new URL(wellKnownOpenIDConfigurationUrl);
-                HttpRequest request = new NetHttpTransport.Builder().build().createRequestFactory()
+                HttpRequest request = constructHttpTransport(disableSslVerification).createRequestFactory()
                                                                     .buildGetRequest(new GenericUrl(url));
                 com.google.api.client.http.HttpResponse response = request.execute();
 
-                // Try to parse the response. If it's not valid, a JsonParseExceptino will be thrown indicating
+                // Try to parse the response. If it's not valid, a JsonParseException will be thrown indicating
                 // that it's not a valid JSON describing an OpenID Connect endpoint
                 WellKnownOpenIDConfigurationResponse config = OicSecurityRealm.JSON_FACTORY
                         .fromInputStream(response.getContent(), Charset.defaultCharset(),

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -6,66 +6,84 @@
   <f:entry title="${%Client secret}" field="clientSecret">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%Token server url}" field="tokenServerUrl">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Authorization server url}" field="authorizationServerUrl">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%UserInfo server url}" field="userInfoServerUrl">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%User name field}" field="userNameField">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Token Field Key To Check}" field="tokenFieldToCheckKey">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Token Field Value To Check}" field="tokenFieldToCheckValue">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%FullName field name}" field="fullNameFieldName">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Email field name}" field="emailFieldName">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Scopes}" field="scopes">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Groups field name}" field="groupsFieldName">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Disable ssl verification}" field="disableSslVerification">
-    <f:checkbox/>
-  </f:entry>
 
-  <f:block>
-    <table>
-      <f:optionalBlock inline="true" title="${%Logout from OpenID Provider}" field="logoutFromOpenidProvider" checked="${logoutFromOpenidProvider}">
-          <f:entry title="${%End session URL for OpenID Provider}" field="endSessionUrl">
-            <f:textbox/>
-          </f:entry>
-          <f:entry title="${%Post logout redirect URL}" field="postLogoutRedirectUrl">
-            <f:textbox/>
-          </f:entry>
-      </f:optionalBlock>
-    </table>
-  </f:block>
-
-  <f:block>
-    <table>
-      <f:optionalBlock inline="true" title="${%Configure 'escape hatch' for when the OpenID Provider is unavailable}" field="escapeHatchEnabled">
-        <f:entry title="${%Username}" field="escapeHatchUsername">
+  <f:section title="Configuration mode">
+    <f:block>
+      <f:radioBlock title="${%Automatic configuration}" checked="${descriptor.auto}" name="automanualconfigure" value="auto" inline="true">
+        <f:entry title="${%Well-known configuration endpoint}" field="wellKnownOpenIDConfigurationUrl">
           <f:textbox/>
         </f:entry>
-        <f:entry title="${%Secret}" field="escapeHatchSecret">
-          <f:password/>
-        </f:entry>
-        <f:entry title="${%Group}" field="escapeHatchGroup">
-          <f:textbox/>
-        </f:entry>
-      </f:optionalBlock>
-    </table>
-  </f:block>
+      </f:radioBlock>
+    </f:block>
+
+    <f:block>
+    <f:radioBlock title="${%Manual configuration}" checked="${descriptor.manual}" name="automanualconfigure" value="manual" inline="true">
+      <f:entry title="${%Token server url}" field="tokenServerUrl">
+        <f:textbox/>
+      </f:entry>
+      <f:entry title="${%Authorization server url}" field="authorizationServerUrl">
+        <f:textbox/>
+      </f:entry>
+      <f:entry title="${%UserInfo server url}" field="userInfoServerUrl">
+        <f:textbox/>
+      </f:entry>
+      <f:entry title="${%Scopes}" field="scopes">
+        <f:textbox/>
+      </f:entry>
+    </f:radioBlock>
+    </f:block>
+  </f:section>
+
+  <f:advanced>
+    <f:entry title="${%User name field}" field="userNameField">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Token Field Key To Check}" field="tokenFieldToCheckKey">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Token Field Value To Check}" field="tokenFieldToCheckValue">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%FullName field name}" field="fullNameFieldName">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Email field name}" field="emailFieldName">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Groups field name}" field="groupsFieldName">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Disable ssl verification}" field="disableSslVerification">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:block>
+      <table>
+        <f:optionalBlock inline="true" title="${%Logout from OpenID Provider}" field="logoutFromOpenidProvider" checked="${logoutFromOpenidProvider}">
+            <f:entry title="${%End session URL for OpenID Provider}" field="endSessionUrl">
+              <f:textbox/>
+            </f:entry>
+            <f:entry title="${%Post logout redirect URL}" field="postLogoutRedirectUrl">
+              <f:textbox/>
+            </f:entry>
+        </f:optionalBlock>
+      </table>
+    </f:block>
+
+    <f:block>
+      <table>
+        <f:optionalBlock inline="true" title="${%Configure 'escape hatch' for when the OpenID Provider is unavailable}" field="escapeHatchEnabled">
+          <f:entry title="${%Username}" field="escapeHatchUsername">
+            <f:textbox/>
+          </f:entry>
+          <f:entry title="${%Secret}" field="escapeHatchSecret">
+            <f:password/>
+          </f:entry>
+          <f:entry title="${%Group}" field="escapeHatchGroup">
+            <f:textbox/>
+          </f:entry>
+        </f:optionalBlock>
+      </table>
+    </f:block>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-wellKnownOpenIDConfigurationUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-wellKnownOpenIDConfigurationUrl.html
@@ -1,0 +1,3 @@
+<div>
+    The well-known registry URI that can be used to automatically configure the endpoints. This is often in the form http://example.com/.well-known/openid-configuration
+</div>

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -229,6 +229,7 @@ public class PluginTest {
             super(
                  CLIENT_ID,
                 "secret",
+                null,
                 "http://localhost:" + wireMockRule.port() + "/token",
                 "http://localhost:" + wireMockRule.port() + "/authorization",
                  userInfoServerUrl,
@@ -246,7 +247,8 @@ public class PluginTest {
                 false,
                 null,
                 null,
-                null
+                null,
+                "manual"
             );
         }
 

--- a/src/test/java/org/jenkinsci/plugins/oic/WellKnownOpenIDConfigurationResponseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/WellKnownOpenIDConfigurationResponseTest.java
@@ -1,0 +1,91 @@
+package org.jenkinsci.plugins.oic;
+
+import java.io.IOException;
+import com.google.api.client.auth.oauth2.WellKnownOpenIDConfigurationResponse;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+public class WellKnownOpenIDConfigurationResponseTest {
+
+    private final JsonFactory jsonFactory = new JacksonFactory();
+
+    private static final String JSON_FROM_GOOGLE = "{"
+           + " \"issuer\": \"https://accounts.google.com\","
+           + " \"authorization_endpoint\": \"https://accounts.google.com/o/oauth2/v2/auth\","
+           + " \"token_endpoint\": \"https://www.googleapis.com/oauth2/v4/token\","
+           + " \"userinfo_endpoint\": \"https://www.googleapis.com/oauth2/v3/userinfo\","
+           + " \"revocation_endpoint\": \"https://accounts.google.com/o/oauth2/revoke\","
+           + " \"jwks_uri\": \"https://www.googleapis.com/oauth2/v3/certs\","
+           + " \"response_types_supported\": ["
+               + "  \"code\","
+               + "  \"token\","
+               + "  \"id_token\","
+               + "  \"code token\","
+               + "  \"code id_token\","
+               + "  \"token id_token\","
+               + "  \"code token id_token\","
+               + "  \"none\""
+           + " ],"
+           + " \"subject_types_supported\": ["
+               + "  \"public\""
+           + " ],"
+           + " \"id_token_signing_alg_values_supported\": ["
+           + "  \"RS256\""
+           + " ],"
+           + " \"scopes_supported\": ["
+               + "  \"openid\","
+               + "  \"email\","
+               + "  \"profile\""
+           + " ],"
+           + " \"token_endpoint_auth_methods_supported\": ["
+               + "  \"client_secret_post\","
+               + "  \"client_secret_basic\""
+           + " ],"
+           + " \"claims_supported\": ["
+               + "  \"aud\","
+               + "  \"email\","
+               + "  \"email_verified\","
+               + "  \"exp\","
+               + "  \"family_name\","
+               + "  \"given_name\","
+               + "  \"iat\","
+               + "  \"iss\","
+               + "  \"locale\","
+               + "  \"name\","
+               + "  \"picture\","
+               + "  \"sub\""
+           + " ],"
+           + " \"code_challenge_methods_supported\": ["
+               + "  \"plain\","
+               + "  \"S256\""
+           + " ]"
+       + "}";
+
+    @Test
+    public void parseExplicitKeys() throws IOException {
+        WellKnownOpenIDConfigurationResponse response = jsonFactory.fromString(JSON_FROM_GOOGLE, WellKnownOpenIDConfigurationResponse.class);
+
+        assertThat(response.getAuthorizationEndpoint(), is("https://accounts.google.com/o/oauth2/v2/auth"));
+        assertThat(response.getTokenEndpoint(), is("https://www.googleapis.com/oauth2/v4/token"));
+        assertThat(response.getUserinfoEndpoint(), is("https://www.googleapis.com/oauth2/v3/userinfo"));
+        assertThat(response.getJwksUri(), is("https://www.googleapis.com/oauth2/v3/certs"));
+        assertThat(response.getScopesSupported(), containsInAnyOrder("openid", "email", "profile"));
+    }
+
+    @Test
+    public void parseWellKnownKeys() throws IOException {
+        WellKnownOpenIDConfigurationResponse response = jsonFactory.fromString(JSON_FROM_GOOGLE, WellKnownOpenIDConfigurationResponse.class);
+        assertThat(response.getKnownKeys().keySet(), containsInAnyOrder(
+            "authorization_endpoint",
+            "token_endpoint",
+            "userinfo_endpoint",
+            "jwks_uri",
+            "scopes_supported"
+        ));
+    }
+
+}


### PR DESCRIPTION
See https://openid.net/specs/openid-connect-discovery-1_0.html

I also grouped some of the advanced parameters under the 'advanced' box:

![image](https://user-images.githubusercontent.com/1652511/40237243-c02f19d8-5aa7-11e8-9138-a4e4365cef48.png)

![image](https://user-images.githubusercontent.com/1652511/40237275-daa1098e-5aa7-11e8-96ba-3d4ea1fe269b.png)

It does the actual fetching/setting of the endpoints in the data-bound constructor, so after you enter in the autodiscovery endpoint, if you hit apply, you will have to hit refresh to see the data populated in the 'manual' configuration section.