### PR TITLE
Don't send scope parameter with a token request

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.oic;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.auth.oauth2.AuthorizationCodeTokenRequest;
 import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
 import com.google.api.client.auth.openidconnect.IdToken;
@@ -47,6 +48,7 @@ import hudson.tasks.Mailer;
 import hudson.util.FormValidation;
 import hudson.util.HttpResponses;
 import hudson.util.Secret;
+import java.util.Collections;
 import jenkins.model.Jenkins;
 import org.acegisecurity.*;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -359,8 +361,12 @@ public class OicSecurityRealm extends SecurityRealm {
             @Override
             public HttpResponse onSuccess(String authorizationCode) {
                 try {
-                    IdTokenResponse response = IdTokenResponse.execute(
-                            flow.newTokenRequest(authorizationCode).setRedirectUri(buildOAuthRedirectUrl()));
+                    AuthorizationCodeTokenRequest tokenRequest = flow.newTokenRequest(authorizationCode)
+                        .setRedirectUri(buildOAuthRedirectUrl());
+                    // Supplying scope is not allowed when obtaining an access token with an authorization code.
+                    tokenRequest.setScopes(Collections.<String>emptyList());
+
+                    IdTokenResponse response = IdTokenResponse.execute(tokenRequest);
 
                     this.setIdToken(response.getIdToken());
 


### PR DESCRIPTION
The 'scope' parameter is not allowed to be send with an access token request based on an authorization code.

See: https://openid.net/specs/openid-connect-basic-1_0.html#ObtainingTokens section 2.1.6.1.

I bumped in to this issue with Wren:AM (OpenAM fork) which complains about the invalid scope parameter and comes to a grinding halt.

EDIT: I stated Ouath2 allowed it but OIDC dit not. I did some digging and I think OAuth2 probably also doesn't allow it. [rfc6749 section 4.1.3](https://tools.ietf.org/html/rfc6749#section-4.1.3) does not specify scope as a valid field.