### PR TITLE
Fix for https://github.com/jenkinsci/oic-auth-plugin/issues/54 as we

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,12 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>2.37</version>
   </parent>
 
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
+    <jenkins.version>2.150.2</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <artifactId>oic-auth</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
@@ -107,7 +107,7 @@ abstract class OicSession {
         } else if (code == null) {
             return new Failure("Missing authorization code");
         } else {
-            return onSuccess(code);
+            return onSuccess(request, code);
         }
     }
 
@@ -124,7 +124,7 @@ abstract class OicSession {
         return this.state;
     }
 
-    protected abstract HttpResponse onSuccess(String authorizationCode);
+    protected abstract HttpResponse onSuccess(StaplerRequest request, String authorizationCode);
 
     /**
      * Gets the {@link OicSession} associated with HTTP session in the current extend.


### PR DESCRIPTION
rely on new code introduced in 2.150.2 we now also depend on >2.150.2 As
this is related to security it might not be a bad thing, protecting
others from themselves.

The actual fix is setting the session attributed related to the
UserSeed.