### PR TITLE
[JENKINS-55654] Fix authentication loop

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -48,6 +48,7 @@ import hudson.util.FormValidation;
 import hudson.util.HttpResponses;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
+import jenkins.security.SecurityListener;
 import org.acegisecurity.*;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
@@ -491,6 +492,9 @@ public class OicSecurityRealm extends SecurityRealm {
         if (fullName != null) {
             user.setFullName(fullName);
         }
+
+        OicUserDetails userDetails = new OicUserDetails(userName, grantedAuthorities);
+        SecurityListener.fireAuthenticated(userDetails);
 
         return token;
     }


### PR DESCRIPTION
- trigger the authenticated event to have the core mechanism
  that will add the seed to the session/cookie

See [JENKINS-55654](https://issues.jenkins-ci.org/browse/JENKINS-55654) and also #54.