### PR TITLE
Nullpointer on nonexistent session 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -607,7 +607,12 @@ public class OicSecurityRealm extends SecurityRealm {
      * @return an HttpResponse
     */
     public HttpResponse doFinishLogin(StaplerRequest request) {
-        return OicSession.getCurrent().doFinishLogin(request);
+    	OicSession currentSession = OicSession.getCurrent();
+    	if(currentSession==null) {
+    		LOGGER.fine("No session to resume (perhaps jenkins was restarted?)");
+    		return HttpResponses.errorWithoutStack(401, "Unauthorized");
+    	}
+        return currentSession.doFinishLogin(request);
     }
 
     /**


### PR DESCRIPTION
When Jenkins is restarted(or session information otherwise lost) half way through the interaction it might not have a session at this point.