### PR TITLE
Fix: wrong return value of failedCheckOfTokenField

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -470,7 +470,7 @@ public class OicSecurityRealm extends SecurityRealm {
             return true;
         }
 
-        return tokenFieldToCheckValue.equals(String.valueOf(value));
+        return !tokenFieldToCheckValue.equals(String.valueOf(value));
     }
 
     private UsernamePasswordAuthenticationToken loginAndSetUserData(String userName, IdToken idToken, GenericJson userInfo) throws IOException {


### PR DESCRIPTION
The return value is exactly the opposite of desired. If field check is success, the equal assertion returns true, but method `failedCheckOfTokenField` should return false, not true.