### PR TITLE
Check for groups in idToken if groups are not found in userInfo

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -542,32 +542,26 @@ public class OicSecurityRealm extends SecurityRealm {
         grantedAuthorities.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
 
         if (isNotBlank(groupsFieldName)) {
-            if(Strings.isNullOrEmpty(userInfoServerUrl)) {
-                if (containsField(idToken.getPayload(), groupsFieldName)) {
-                    LOGGER.fine("idToken contains group field name: " + groupsFieldName + " with value class:" + getField(idToken.getPayload(), groupsFieldName).getClass());
-                    @SuppressWarnings("unchecked")
-                    List<String> groupNames = (List<String>) getField(idToken.getPayload(), groupsFieldName);
-                    LOGGER.fine("Number of groups in groupNames: " + groupNames.size());
-                    for (String groupName : groupNames) {
-                        LOGGER.fine("Adding group from idToken: " + groupName);
-                        grantedAuthorities.add(new GrantedAuthorityImpl(groupName));
-                    }
-                } else {
-                    LOGGER.warning("idToken did not contain group field name: " + groupsFieldName);
+            if (!Strings.isNullOrEmpty(userInfoServerUrl) && containsField(userInfo, groupsFieldName)) {
+                LOGGER.fine("UserInfo contains group field name: " + groupsFieldName + " with value class:" + getField(userInfo, groupsFieldName).getClass());
+                @SuppressWarnings("unchecked")
+                List<String> groupNames = (List<String>) getField(userInfo, groupsFieldName);
+                LOGGER.fine("Number of groups in groupNames: " + groupNames.size());
+                for (String groupName : groupNames) {
+                    LOGGER.fine("Adding group from UserInfo: " + groupName);
+                    grantedAuthorities.add(new GrantedAuthorityImpl(groupName));
+                }
+            } else if (containsField(idToken.getPayload(), groupsFieldName)) {
+                LOGGER.fine("idToken contains group field name: " + groupsFieldName + " with value class:" + getField(idToken.getPayload(), groupsFieldName).getClass());
+                @SuppressWarnings("unchecked")
+                List<String> groupNames = (List<String>) getField(idToken.getPayload(), groupsFieldName);
+                LOGGER.fine("Number of groups in groupNames: " + groupNames.size());
+                for (String groupName : groupNames) {
+                    LOGGER.fine("Adding group from idToken: " + groupName);
+                    grantedAuthorities.add(new GrantedAuthorityImpl(groupName));
                 }
             } else {
-                if (containsField(userInfo, groupsFieldName)) {
-                    LOGGER.fine("UserInfo contains group field name: " + groupsFieldName + " with value class:" + getField(userInfo, groupsFieldName).getClass());
-                    @SuppressWarnings("unchecked")
-                    List<String> groupNames = (List<String>) getField(userInfo, groupsFieldName);
-                    LOGGER.fine("Number of groups in groupNames: " + groupNames.size());
-                    for (String groupName : groupNames) {
-                        LOGGER.fine("Adding group from UserInfo: " + groupName);
-                        grantedAuthorities.add(new GrantedAuthorityImpl(groupName));
-                    }
-                } else {
-                    LOGGER.warning("UserInfo did not contain group field name: " + groupsFieldName);
-                }
+                LOGGER.warning("idToken and userInfo did not contain group field name: " + groupsFieldName);
             }
         } else {
             LOGGER.fine("Not adding groups because groupsFieldName is not set. groupsFieldName=" + groupsFieldName);


### PR DESCRIPTION
This PR fixes following behaviour - currently, if `userInfo` is not empty and field `groupsFieldName` is not set in `userInfo`, group lookup stops. Expected behaviour would be to check the presence of groups in `idToken` as well.

_Current behaviour also seems to be a regression after f8aa9826e54ca77ae8195c7fa099bf68bedb9969, since previously only `idToken` was used for groups._