### PR TITLE
Look for a known user, or return UsernameNotFoundException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -329,7 +329,11 @@ public class OicSecurityRealm extends SecurityRealm {
 					public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
 						// Retrieve the OicUserProperty to get the list of groups that has to be set in the OicUserDetails object.
 						LOGGER.fine("loadUserByUsername in createSecurityComponents called, username: " + username);
-						User u = User.get(username);
+						User u = User.get(username, false, Collections.emptyMap());
+						if (u == null) {
+							LOGGER.fine("loadUserByUsername in createSecurityComponents called, no user '" + username + "' found");
+							throw new UsernameNotFoundException(username);
+						}
 						LOGGER.fine("loadUserByUsername in createSecurityComponents called, user: " + u);
 						List<UserProperty> props = u.getAllProperties();
 						LOGGER.fine("loadUserByUsername in createSecurityComponents called, number of props: " + props.size());


### PR DESCRIPTION
I took a peek at the [Saml plugin](https://github.com/jenkinsci/saml-plugin/blob/master/src/main/java/org/jenkinsci/plugins/saml/SamlUserDetailsService.java#L50-L53)

See also https://javadoc.jenkins-ci.org/hudson/model/User.html

The function `User.get(String idOrFullName)` is deprecated. I replaced
it in my local code with `User.get(String idOrFullName, boolean create,
Map context)`, with `create=false`. I check if the result is `null`, in
which case we return a `UsernameNotFoundException`.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>