### PR TITLE
Properly restore GrantedAuthorities

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -340,17 +340,12 @@ public class OicSecurityRealm extends SecurityRealm {
 							throw new UsernameNotFoundException(username);
 						}
 						LOGGER.fine("loadUserByUsername in createSecurityComponents called, user: " + u);
-						List<UserProperty> props = u.getAllProperties();
-						LOGGER.fine("loadUserByUsername in createSecurityComponents called, number of props: " + props.size());
+						OicUserProperty oicProp = u.getProperty(OicUserProperty.class);
 						GrantedAuthority[] auths = new GrantedAuthority[0];
-						for (UserProperty prop: props) {
-							LOGGER.fine("loadUserByUsername in createSecurityComponents called, prop of type: " + prop.getClass().toString());
-							if (prop instanceof OicUserProperty) {
-								OicUserProperty oicProp = (OicUserProperty) prop;
-								LOGGER.fine("loadUserByUsername in createSecurityComponents called, oic prop found with username: " + oicProp.getUserName());
-								auths = oicProp.getAuthoritiesAsGrantedAuthorities();
-								LOGGER.fine("loadUserByUsername in createSecurityComponents called, oic prop with auths size: " + auths.length);
-							}
+						if (oicProp != null) {
+							LOGGER.fine("loadUserByUsername in createSecurityComponents called, oic prop found with username: " + oicProp.getUserName());
+							auths = oicProp.getAuthoritiesAsGrantedAuthorities();
+							LOGGER.fine("loadUserByUsername in createSecurityComponents called, oic prop with auths size: " + auths.length);
 						}
 						return new OicUserDetails(username, auths);
 					}


### PR DESCRIPTION
In the custom UserDetailsService implementation, getAllProperties() was
used to restore the GrantedAuthorities, which won't work for non-admin
users. Replace that with a call to getProperty(), which behaves as
expected.

Fixes #41.
Fixes #87.