### PR TITLE
Fix OIDC group parsing as string

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -577,7 +577,7 @@ public class OicSecurityRealm extends SecurityRealm {
             // We try to convert the string to list based on comma while ignoring whitespaces and square brackets.
             // Example value "[demo-user-group, demo-test-group, demo-admin-group]"
             String sField= (String) field;
-            String[] rawFields = sField.split("[\\s\\[\\],]");
+            String[] rawFields = sField.split("[\\s\\[\\]]");
             List<String> result = new ArrayList<>();
             for (String rawField : rawFields) {
                 if (rawField != null && !rawField.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -575,7 +575,7 @@ public class OicSecurityRealm extends SecurityRealm {
         if (field instanceof String) {
             // if its a String, the original value was not a json array.
             // We try to convert the string to list based on comma while ignoring whitespaces and square brackets.
-            // Example value "[demo-user-group, demo-test-group, demo-admin-group]"
+            // Example value "[CN="abc",OU="org1"]"
             String sField= (String) field;
             String[] rawFields = sField.split("[\\s\\[\\]]");
             List<String> result = new ArrayList<>();

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -332,7 +332,7 @@ public class PluginTest {
                                 "   \""+FULL_NAME_FIELD+"\": \""+TEST_USER_FULL_NAME+"\",\n" +
                                 "   \"nested\": {\n" +
                                 "     \"email\": \""+TEST_USER_EMAIL_ADDRESS+"\",\n" +
-                                "     \"groups\": \"["+TEST_USER_GROUPS[0]+", "+TEST_USER_GROUPS[1]+"]\"\n" +
+                                "     \"groups\": \"["+TEST_USER_GROUPS[0]+"]\"\n" +
                                 "   }\n" +
                                 "  }")
         ));
@@ -351,8 +351,7 @@ public class PluginTest {
         assertEquals("Full name should be "+TEST_USER_FULL_NAME, TEST_USER_FULL_NAME, user.getFullName());
         assertEquals("Email should be "+ TEST_USER_EMAIL_ADDRESS, TEST_USER_EMAIL_ADDRESS, user.getProperty(Mailer.UserProperty.class).getAddress());
         assertTrue("User should be part of group "+ TEST_USER_GROUPS[0], user.getAuthorities().contains(TEST_USER_GROUPS[0]));
-        assertTrue("User should be part of group "+ TEST_USER_GROUPS[1], user.getAuthorities().contains(TEST_USER_GROUPS[1]));
-        assertEquals("User should be in 2 groups", 2, user.getAuthorities().size());
+        assertEquals("User should be in 1 groups", 1, user.getAuthorities().size());
     }
 
     private String toJsonArray(String[] array) {

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -300,6 +300,61 @@ public class PluginTest {
         assertTrue("User should be part of group "+ TEST_USER_GROUPS[1], user.getAuthorities().contains(TEST_USER_GROUPS[1]));
     }
 
+    @Test public void testGroupListFromStringInfoEndpoint() throws Exception {
+        wireMockRule.resetAll();
+
+        KeyPair keyPair = createKeyPair();
+
+        wireMockRule.stubFor(get(urlPathEqualTo("/authorization")).willReturn(
+                aResponse()
+                        .withStatus(302)
+                        .withHeader("Content-Type", "text/html; charset=utf-8")
+                        .withHeader("Location", jenkins.getRootUrl()+"securityRealm/finishLogin?state=state&code=code")
+                        .withBody("")
+        ));
+        wireMockRule.stubFor(post(urlPathEqualTo("/token")).willReturn(
+                aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{" +
+                                "\"id_token\": \""+createIdToken(keyPair.getPrivate(),Collections.<String,Object>emptyMap())+"\"," +
+                                "\"access_token\":\"AcCeSs_ToKeN\"," +
+                                "\"token_type\":\"example\"," +
+                                "\"expires_in\":3600," +
+                                "\"refresh_token\":\"ReFrEsH_ToKeN\"," +
+                                "\"example_parameter\":\"example_value\"" +
+                                "}")
+        ));
+        wireMockRule.stubFor(get(urlPathEqualTo("/userinfo")).willReturn(
+                aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\n" +
+                                "   \"sub\": \""+TEST_USER_USERNAME+"\",\n" +
+                                "   \""+FULL_NAME_FIELD+"\": \""+TEST_USER_FULL_NAME+"\",\n" +
+                                "   \"nested\": {\n" +
+                                "     \"email\": \""+TEST_USER_EMAIL_ADDRESS+"\",\n" +
+                                "     \"groups\": \"["+TEST_USER_GROUPS[0]+", "+TEST_USER_GROUPS[1]+"]\"\n" +
+                                "   }\n" +
+                                "  }")
+        ));
+
+
+        jenkins.setSecurityRealm(new TestRealm(wireMockRule, "http://localhost:" + wireMockRule.port() + "/userinfo", "nested.email", "nested.groups"));
+
+        assertEquals("Shouldn't be authenticated", getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
+
+        webClient.goTo(jenkins.getSecurityRealm().getLoginUrl());
+
+        Authentication authentication = getAuthentication();
+        assertEquals("Should be logged-in as "+ TEST_USER_USERNAME, authentication.getPrincipal(), TEST_USER_USERNAME);
+        User user = User.get(String.valueOf(authentication.getPrincipal()));
+
+        assertEquals("Full name should be "+TEST_USER_FULL_NAME, TEST_USER_FULL_NAME, user.getFullName());
+        assertEquals("Email should be "+ TEST_USER_EMAIL_ADDRESS, TEST_USER_EMAIL_ADDRESS, user.getProperty(Mailer.UserProperty.class).getAddress());
+        assertTrue("User should be part of group "+ TEST_USER_GROUPS[0], user.getAuthorities().contains(TEST_USER_GROUPS[0]));
+        assertTrue("User should be part of group "+ TEST_USER_GROUPS[1], user.getAuthorities().contains(TEST_USER_GROUPS[1]));
+        assertEquals("User should be in 2 groups", 2, user.getAuthorities().size());
+    }
+
     private String toJsonArray(String[] array) {
         StringBuilder builder = new StringBuilder();
         builder.append("[");


### PR DESCRIPTION
Plugin fails to parse the group membership when the user is a member of only one group. The parser throws an exception trying to parse groupfields from the openid response
```
2022-04-06 11:52:49.451+0000 [id=59672]	WARNING	h.i.i.InstallUncaughtExceptionHandler#handleException: Caught unhandled exception with ID b9e644dd-8603-49e0-ba72-c2fd7af2aafd
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.List (java.lang.String and java.util.List are in module java.base of loader 'bootstrap')
	at org.jenkinsci.plugins.oic.OicSecurityRealm.determineAuthorities(OicSecurityRealm.java:548)
	at org.jenkinsci.plugins.oic.OicSecurityRealm.loginAndSetUserData(OicSecurityRealm.java:502)
	at org.jenkinsci.plugins.oic.OicSecurityRealm.access$700(OicSecurityRealm.java:90)
	at org.jenkinsci.plugins.oic.OicSecurityRealm$3.onSuccess(OicSecurityRealm.java:421)
	at org.jenkinsci.plugins.oic.OicSession.doFinishLogin(OicSession.java:110)
	at org.jenkinsci.plugins.oic.OicSecurityRealm.doFinishLogin(OicSecurityRealm.java:651)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:398)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:410)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:208)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:141)
	at org.kohsuke.stapler.MetaClass$11.doDispatch(MetaClass.java:558)
	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:59)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
```
This issue is related to this Jenkins issue https://issues.jenkins.io/browse/JENKINS-61609

The parsing of groups have been modified to specially handle the string type when deserialized by the api response deserializer.
The string type group fields are split using regex to get the claim information properly captured from the response.
This fix was inspired from the changes in this previous PR  https://github.com/jenkinsci/oic-auth-plugin/pull/90

Related issues: 
https://github.com/jenkinsci/oic-auth-plugin/issues/120
https://github.com/jenkinsci/oic-auth-plugin/issues/49

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
