### PR TITLE
Support application/jwt when invoking userinfo

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -45,7 +45,6 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
-import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.Data;
 import com.google.common.base.Strings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;


### PR DESCRIPTION
A described in https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse

> Upon receipt of the UserInfo Request, the UserInfo Endpoint MUST return the JSON Serialization of the UserInfo Response as in [Section 13.3](https://openid.net/specs/openid-connect-core-1_0.html#JSONSerialization) in the HTTP response body unless a different format was specified during Registration [[OpenID.Registration]](https://openid.net/specs/openid-connect-core-1_0.html#OpenID.Registration). The UserInfo Endpoint MUST return a content-type header to indicate which format is being returned. The content-type of the HTTP response MUST be application/json if the response body is a text JSON object; the response body SHOULD be encoded using UTF-8.

>
>If the UserInfo Response is signed and/or encrypted, then the Claims are returned in a JWT and the content-type MUST be application/jwt. The response MAY be encrypted without also being signed. If both signing and encryption are requested, the response MUST be signed then encrypted, with the result being a Nested JWT, as defined in [[JWT]](https://openid.net/specs/openid-connect-core-1_0.html#JWT).

And more clearly in https://openid.net/specs/openid-connect-basic-1_0.html

> The UserInfo Endpoint MUST return Claims in JSON format unless a different format was specified during Registration<span> </span><a class="info" href="https://openid.net/specs/openid-connect-basic-1_0.html#OpenID.Registration" style="font-weight: bold; position: relative; z-index: 24; text-decoration: none; color: rgb(153, 0, 0); background-color: transparent;">[OpenID.Registration]</a>. The UserInfo Endpoint MUST return a content-type header to indicate which format is being returned. The following are accepted content types:</p>

Content-Type | Format Returned
-- | --
application/json | plain text JSON object
application/jwt | JSON Web Token (JWT)


Signed-off-by: Guillermo Pérez <1122459+gperezmz@users.noreply.github.com>
