### PR TITLE
Use own token for generic OIDConnect

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -30,7 +30,6 @@ import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
 import com.google.api.client.auth.oauth2.Credential.AccessMethod;
 import com.google.api.client.auth.openidconnect.IdToken;
-import com.google.api.client.auth.openidconnect.IdTokenResponse;
 import com.google.api.client.http.BasicAuthentication;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpExecuteInterceptor;
@@ -470,11 +469,11 @@ public class OicSecurityRealm extends SecurityRealm {
                     // Supplying scope is not allowed when obtaining an access token with an authorization code.
                     tokenRequest.setScopes(Collections.<String>emptyList());
 
-                    IdTokenResponse response = IdTokenResponse.execute(tokenRequest);
+                    OicTokenResponse response = (OicTokenResponse) tokenRequest.execute();
 
                     this.setIdToken(response.getIdToken());
 
-                    IdToken idToken = IdToken.parse(JSON_FACTORY, response.getIdToken());
+                    IdToken idToken = response.parseIdToken();
 
                     Object username;
                     GenericJson userInfo = null;

--- a/src/main/java/org/jenkinsci/plugins/oic/OicTokenResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicTokenResponse.java
@@ -24,15 +24,34 @@
 package org.jenkinsci.plugins.oic;
 
 import com.google.api.client.auth.oauth2.TokenResponse;
+import com.google.api.client.auth.openidconnect.IdToken;
 import com.google.api.client.util.Key;
+import hudson.Util;
+import java.io.IOException;
 import java.util.Objects;
 
-/**  Custom TokenResponse
+/**  Custom TokenResponse with id_token capabilities
 *
 * Customisation includes:
 * - expires_in: can be Long or String of Long
 */
 public class OicTokenResponse extends TokenResponse {
+
+    @Key("id_token")
+    private String idToken;
+
+    public final String getIdToken() {
+        return this.idToken;
+    }
+
+    public OicTokenResponse setIdToken(String str) {
+        this.idToken = (String) Util.fixNull(str);
+        return this;
+    }
+
+    public IdToken parseIdToken() throws IOException {
+        return IdToken.parse(getFactory(), this.idToken);
+    }
 
     /**
      * Lifetime in seconds of the access token (for example 3600 for an hour) or {@code null} for
@@ -98,5 +117,36 @@ public class OicTokenResponse extends TokenResponse {
     @Override
     public int hashCode() {
         return super.hashCode();
+    }
+
+    // ---- override com.google.api.client.auth.oauth2.TokenResponse
+
+    @Override // com.google.api.client.auth.oauth2.TokenResponse, com.google.api.client.json.GenericJson, com.google.api.client.util.GenericData
+    public OicTokenResponse set(String str, Object obj) {
+        return (OicTokenResponse) super.set(str, obj);
+    }
+
+    @Override // com.google.api.client.auth.oauth2.TokenResponse
+    public OicTokenResponse setAccessToken(String str) {
+        super.setAccessToken(str);
+        return this;
+    }
+
+    @Override // com.google.api.client.auth.oauth2.TokenResponse
+    public OicTokenResponse setRefreshToken(String str) {
+        super.setRefreshToken(str);
+        return this;
+    }
+
+    @Override // com.google.api.client.auth.oauth2.TokenResponse
+    public OicTokenResponse setScope(String str) {
+        super.setScope(str);
+        return this;
+    }
+
+    @Override // com.google.api.client.auth.oauth2.TokenResponse
+    public OicTokenResponse setTokenType(String str) {
+        super.setTokenType(str);
+        return this;
     }
 }


### PR DESCRIPTION
Using google OpenIdConnectResponse did not actually override parsing of `expires_in`.
Getting rid of it in fovor of custom OicTokenResponse and fixes #182.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
