### PR TITLE
Add configuration flag to send scopes in token request

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -161,6 +161,10 @@ public class OicSecurityRealm extends SecurityRealm {
      */
     private boolean rootURLFromRequest = false;
 
+    /** Flag to send scopes in code token request
+     */
+    private boolean sendScopesInTokenRequest = false;
+
     /** old field that had an '/' implicitly added at the end,
      * transient because we no longer want to have this value stored
      * but it's still needed for backwards compatibility */
@@ -386,6 +390,10 @@ public class OicSecurityRealm extends SecurityRealm {
         return rootURLFromRequest;
     }
 
+    public boolean isSendScopesInTokenRequest() {
+        return sendScopesInTokenRequest;
+    }
+
     public boolean isAutoConfigure() {
         return "auto".equals(this.automanualconfigure);
     }
@@ -523,6 +531,11 @@ public class OicSecurityRealm extends SecurityRealm {
         this.rootURLFromRequest = rootURLFromRequest;
     }
 
+    @DataBoundSetter
+    public void setSendScopesInTokenRequest(boolean sendScopesInTokenRequest) {
+        this.sendScopesInTokenRequest = sendScopesInTokenRequest;
+    }
+
     @Override
     public String getLoginUrl() {
         //Login begins with our doCommenceLogin(String,String) method
@@ -639,8 +652,9 @@ public class OicSecurityRealm extends SecurityRealm {
                     AuthorizationCodeTokenRequest tokenRequest = flow.newTokenRequest(authorizationCode)
                         .setRedirectUri(buildOAuthRedirectUrl())
                         .setResponseClass(OicTokenResponse.class);
-                    // Supplying scope is not allowed when obtaining an access token with an authorization code.
-                    tokenRequest.setScopes(Collections.<String>emptyList());
+                    if (!sendScopesInTokenRequest) {
+                        tokenRequest.setScopes(Collections.<String>emptyList());
+                    }
 
                     OicTokenResponse response = (OicTokenResponse) tokenRequest.execute();
 

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -86,6 +86,9 @@
     <f:entry title="${%Use Root URL from request}" field="rootURLFromRequest">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Send scopes in token request}" field="sendScopesInTokenRequest">
+      <f:checkbox/>
+    </f:entry>
 
     <f:block>
       <table>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-sendScopesInTokenRequest.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-sendScopesInTokenRequest.html
@@ -1,0 +1,4 @@
+<div>
+    Supplying scope is not allowed when obtaining an access token with an authorization code.
+	Some non-compliant providers do require the scopes.
+</div>

--- a/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
+++ b/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
@@ -18,3 +18,4 @@ jenkins:
       tokenServerUrl: http://localhost
       userNameField: userNameField
       rootURLFromRequest: true
+      sendScopesInTokenRequest: true

--- a/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCodeExport.yml
+++ b/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCodeExport.yml
@@ -9,6 +9,7 @@ fullNameFieldName: "fullNameFieldName"
 groupsFieldName: "groupsFieldName"
 rootURLFromRequest: true
 scopes: "scopes"
+sendScopesInTokenRequest: true
 tokenAuthMethod: "client_secret_post"
 tokenServerUrl: "http://localhost"
 userNameField: "userNameField"


### PR DESCRIPTION
Some providers need scopes to be provides when requesting the token in the code flow and some fails if the scope are provided. The flag should be activated depending on the provider flavour.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
