### PR TITLE
Add config option to enable PKCE

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -165,6 +165,10 @@ public class OicSecurityRealm extends SecurityRealm {
      */
     private boolean sendScopesInTokenRequest = false;
 
+    /** Flag to enable PKCE challenge
+     */
+    private boolean pkceEnabled = false;
+
     /** old field that had an '/' implicitly added at the end,
      * transient because we no longer want to have this value stored
      * but it's still needed for backwards compatibility */
@@ -394,6 +398,10 @@ public class OicSecurityRealm extends SecurityRealm {
         return sendScopesInTokenRequest;
     }
 
+    public boolean isPkceEnabled() {
+        return pkceEnabled;
+    }
+
     public boolean isAutoConfigure() {
         return "auto".equals(this.automanualconfigure);
     }
@@ -536,6 +544,11 @@ public class OicSecurityRealm extends SecurityRealm {
         this.sendScopesInTokenRequest = sendScopesInTokenRequest;
     }
 
+    @DataBoundSetter
+    public void setPkceEnabled(boolean pkceEnabled) {
+        this.pkceEnabled = pkceEnabled;
+    }
+
     @Override
     public String getLoginUrl() {
         //Login begins with our doCommenceLogin(String,String) method
@@ -620,7 +633,7 @@ public class OicSecurityRealm extends SecurityRealm {
             tokenAccessMethod = BearerToken.authorizationHeaderAccessMethod();
             authInterceptor = new BasicAuthentication(clientId, Secret.toString(clientSecret));
         }
-        return new AuthorizationCodeFlow.Builder(
+        AuthorizationCodeFlow.Builder builder = new AuthorizationCodeFlow.Builder(
                 tokenAccessMethod,
                 httpTransport,
                 JSON_FACTORY,
@@ -629,8 +642,13 @@ public class OicSecurityRealm extends SecurityRealm {
                 clientId,
                 authorizationServerUrl
         )
-            .setScopes(Arrays.asList(this.getScopes()))
-            .build();
+            .setScopes(Arrays.asList(this.getScopes()));
+
+        if(pkceEnabled) {
+            builder.enablePKCE();
+        }
+
+        return builder.build();
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -89,6 +89,9 @@
     <f:entry title="${%Post logout redirect URL}" field="postLogoutRedirectUrl">
       <f:textbox/>
     </f:entry>
+    <f:entry title="${%Enable Proof Key for Code Exchang (PKCE)}" field="pkceEnabled">
+      <f:checkbox/>
+    </f:entry>
 
     <f:block>
       <table>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-pkceEnabled.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-pkceEnabled.html
@@ -1,0 +1,3 @@
+<div>
+     Enable Proof Key for Code Exchange (PKCE)..
+</div>

--- a/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
+++ b/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
@@ -19,3 +19,4 @@ jenkins:
       userNameField: userNameField
       rootURLFromRequest: true
       sendScopesInTokenRequest: true
+      pkceEnabled: true

--- a/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCodeExport.yml
+++ b/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCodeExport.yml
@@ -7,6 +7,7 @@ escapeHatchGroup: "escapeHatchGroup"
 escapeHatchUsername: "escapeHatchUsername"
 fullNameFieldName: "fullNameFieldName"
 groupsFieldName: "groupsFieldName"
+pkceEnabled: true
 rootURLFromRequest: true
 scopes: "scopes"
 sendScopesInTokenRequest: true


### PR DESCRIPTION
Add `pkceEnabled` configuration option to enable PKCE challenge. Note that google library doesn't allow to configure the verification method: it uses S256 if possible and then fallback to plain.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
