### PR TITLE
Allow data containing groups from SSO server to be a List of Maps in addition to a List of Strings. 

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/oic/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/oic/Messages.properties
@@ -16,3 +16,4 @@ OicSecurityRealm.UsingDefaultUsername = Using ''sub''.
 OicSecurityRealm.UsingDefaultScopes = Using ''openid email''.
 OicSecurityRealm.RUSureOpenIdNotInScope = Are you sure you don''t want to include ''openid'' as an scope?
 OicSecurityRealm.EndSessionURLKeyRequired = End Session URL Key is required.
+OicSecurityRealm.UsingDefaultNestedGroupFieldName = Using ''name''.

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -71,6 +71,9 @@
     <f:entry title="${%Groups field name}" field="groupsFieldName">
       <f:textbox/>
     </f:entry>
+    <f:entry title="${%Nested group field name}" field="nestedGroupFieldName">
+      <f:textbox/>
+    </f:entry>
     <f:entry title="${%Token Field Key To Check}" field="tokenFieldToCheckKey">
       <f:textbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-groupsFieldName.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-groupsFieldName.html
@@ -2,4 +2,7 @@
     Not required. If the field exists in the token and is an array of strings, then each string is added as a group.
     This allows groups based authorization in Jenkins. The SSO server will need to add the field with the list of groups in 
     the token. For example in Keycloak, this can be done with a 'Group Membership' mapper in the configuration of the client.
+
+    If the SSO server adds the groups as an array of maps instead, then also use the Nested Group Name field below to specify
+    which element of the map is the group name. 
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-nestedGroupFieldName.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-nestedGroupFieldName.html
@@ -1,0 +1,3 @@
+<div>
+	Not Required.  If your Group Field Name above returns an array of Maps instead of an array of Strings, you may need to specify the filed inside the maps that holds your Group Names.  Default is "name".
+</div>

--- a/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
@@ -55,6 +55,7 @@ public class ConfigurationAsCodeTest {
         assertEquals("escapeHatchUsername", oicSecurityRealm.getEscapeHatchUsername());
         assertEquals("fullNameFieldName", oicSecurityRealm.getFullNameFieldName());
         assertEquals("groupsFieldName", oicSecurityRealm.getGroupsFieldName());
+        assertEquals("nestedGroupFieldName", oicSecurityRealm.getNestedGroupFieldName());
         assertTrue(oicSecurityRealm.isLogoutFromOpenidProvider());
         assertEquals("scopes", oicSecurityRealm.getScopes());
         assertEquals("http://localhost", oicSecurityRealm.getTokenServerUrl());

--- a/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
@@ -32,6 +32,7 @@ public class TestRealm extends OicSecurityRealm {
         public String emailFieldName = null;
         public String scopes = null;
         public String groupsFieldName = null;
+        public String nestedGroupFieldName = null; 
         public boolean disableSslVerification = false;
         public Boolean logoutFromOpenidProvider = false;
         public String endSessionEndpoint = null;
@@ -55,6 +56,7 @@ public class TestRealm extends OicSecurityRealm {
         public Builder WithUserInfoServerUrl(String userInfoServerUrl) { this.userInfoServerUrl = userInfoServerUrl; return this; }
         public Builder WithEmailFieldName(String emailFieldName) { this.emailFieldName = emailFieldName; return this; }
         public Builder WithGroupsFieldName(String groupsFieldName) { this.groupsFieldName = groupsFieldName; return this; }
+        public Builder WithNestedGroupFieldName(String nestedGroupFieldName) { this.nestedGroupFieldName = nestedGroupFieldName; return this; }
         public Builder WithPostLogoutRedirectUrl(String postLogoutRedirectUrl) { this.postLogoutRedirectUrl = postLogoutRedirectUrl; return this; }
     public Builder WithAutomanualconfigure(String automanualconfigure) { this.automanualconfigure = automanualconfigure; return this; }
     public Builder WithScopes(String scopes) { this.scopes = scopes; return this; }
@@ -94,6 +96,7 @@ public class TestRealm extends OicSecurityRealm {
              builder.emailFieldName,
              builder.scopes,
              builder.groupsFieldName,
+             builder.nestedGroupFieldName,
              builder.disableSslVerification,
              builder.logoutFromOpenidProvider,
              builder.endSessionEndpoint,

--- a/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
+++ b/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
@@ -12,6 +12,7 @@ jenkins:
       escapeHatchUsername: escapeHatchUsername
       fullNameFieldName: fullNameFieldName
       groupsFieldName: groupsFieldName
+      nestedGroupFieldName: nestedGroupFieldName
       logoutFromOpenidProvider: true
       scopes: scopes
       tokenAuthMethod: client_secret_post

--- a/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCodeExport.yml
+++ b/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCodeExport.yml
@@ -7,6 +7,7 @@ escapeHatchGroup: "escapeHatchGroup"
 escapeHatchUsername: "escapeHatchUsername"
 fullNameFieldName: "fullNameFieldName"
 groupsFieldName: "groupsFieldName"
+nestedGroupFieldName: "nestedGroupFieldName"
 nonceDisabled: true
 pkceEnabled: true
 rootURLFromRequest: true


### PR DESCRIPTION
Allow data containing groups from SSO server to be a List of Maps in addition to a List of Strings.  In cases where groups is a List of Maps, give option to specify which key in the Map holds the group name, defaulting to a key "name". 

Oracle IDCS is the product we needed to integrate with in this case.  I don't currently know if any other providers need this change.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
