### PR TITLE
Fix 2.6 regression on group field and deprecate Jackson parser (fix #236)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <scm>
     <connection>scm:git:ssh://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+    <developerConnection>scm:git:git@github.com/${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>oic-auth-3.0</tag>
   </scm>
@@ -58,7 +58,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson2</artifactId>
+      <artifactId>google-http-client-gson</artifactId>
       <version>1.44.1</version>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -23,7 +23,6 @@
 */
 package org.jenkinsci.plugins.oic;
 
-import com.google.gson.JsonParseException;
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.api.client.auth.oauth2.AuthorizationCodeTokenRequest;
 import com.google.api.client.auth.oauth2.BearerToken;
@@ -47,6 +46,7 @@ import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.util.ArrayMap;
 import com.google.api.client.util.Data;
 import com.google.common.base.Strings;
+import com.google.gson.JsonParseException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;

--- a/src/test/java/org/jenkinsci/plugins/oic/OicTokenResponseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicTokenResponseTest.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.oic;
 
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -31,8 +30,7 @@ public class OicTokenResponseTest {
 
     @Test
     public void parseLongLiteral() throws IOException {
-        JsonFactory jsonFactory = new JacksonFactory();
-        OicTokenResponse response = jsonFactory.fromString(JSON_WITH_LONG_LITERAL, OicTokenResponse.class);
+        OicTokenResponse response = GsonFactory.getDefaultInstance().fromString(JSON_WITH_LONG_LITERAL, OicTokenResponse.class);
         assertEquals("2YotnFZFEjr1zCsicMWpAA", response.getAccessToken());
         assertEquals("example", response.getTokenType());
         assertEquals(3600L, response.getExpiresInSeconds().longValue());
@@ -42,8 +40,7 @@ public class OicTokenResponseTest {
 
     @Test
     public void parseStringWithLong() throws IOException {
-        JsonFactory jsonFactory = new JacksonFactory();
-        OicTokenResponse response = jsonFactory.fromString(JSON_WITH_LONG_AS_STRING, OicTokenResponse.class);
+        OicTokenResponse response = GsonFactory.getDefaultInstance().fromString(JSON_WITH_LONG_AS_STRING, OicTokenResponse.class);
         assertEquals("2YotnFZFEjr1zCsicMWpAA", response.getAccessToken());
         assertEquals("example", response.getTokenType());
         assertEquals(3600L, response.getExpiresInSeconds().longValue());
@@ -81,8 +78,7 @@ public class OicTokenResponseTest {
 
     @Test
     public void parseAbsent() throws IOException {
-        JsonFactory jsonFactory = new JacksonFactory();
-        OicTokenResponse response = jsonFactory.fromString(JSON_WITH_ABSENT, OicTokenResponse.class);
+        OicTokenResponse response = GsonFactory.getDefaultInstance().fromString(JSON_WITH_ABSENT, OicTokenResponse.class);
         assertEquals("2YotnFZFEjr1zCsicMWpAA", response.getAccessToken());
         assertEquals("example", response.getTokenType());
         assertEquals(null, response.getExpiresInSeconds());

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -3,8 +3,7 @@ package org.jenkinsci.plugins.oic;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.api.client.auth.openidconnect.IdToken;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.ArrayMap;
@@ -59,8 +58,6 @@ import static org.junit.Assert.assertTrue;
  */
 @Url("https://jenkins.io/blog/2018/01/13/jep-200/")
 public class PluginTest {
-    private static final JsonFactory JSON_FACTORY = new JacksonFactory();
-
     private static final String TEST_USER_USERNAME = "testUser";
     private static final String TEST_USER_EMAIL_ADDRESS = "test@jenkins.oic";
     private static final String TEST_USER_FULL_NAME = "Oic Test User";
@@ -1164,7 +1161,7 @@ public class PluginTest {
             payload.set(keyValue.getKey(), keyValue.getValue());
         }
 
-        return JsonWebSignature.signUsingRsaSha256(privateKey, JSON_FACTORY, header, payload);
+        return JsonWebSignature.signUsingRsaSha256(privateKey, GsonFactory.getDefaultInstance(), header, payload);
     }
 
     private String createUserInfoJWT(PrivateKey privateKey, String userInfo) throws Exception {
@@ -1177,7 +1174,7 @@ public class PluginTest {
             payload.set(keyValue.getKey(), keyValue.getValue().getAsString());
         }
 
-        return JsonWebSignature.signUsingRsaSha256(privateKey, JSON_FACTORY, header, payload);
+        return JsonWebSignature.signUsingRsaSha256(privateKey, GsonFactory.getDefaultInstance(), header, payload);
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/oic/WellKnownOpenIDConfigurationResponseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/WellKnownOpenIDConfigurationResponseTest.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.oic;
 
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -12,8 +11,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 public class WellKnownOpenIDConfigurationResponseTest {
-
-    private final JsonFactory jsonFactory = new JacksonFactory();
 
     private static final String JSON_FROM_GOOGLE = "{"
            + " \"issuer\": \"https://accounts.google.com\","
@@ -69,7 +66,7 @@ public class WellKnownOpenIDConfigurationResponseTest {
 
     @Test
     public void parseExplicitKeys() throws IOException {
-        WellKnownOpenIDConfigurationResponse response = jsonFactory.fromString(JSON_FROM_GOOGLE, WellKnownOpenIDConfigurationResponse.class);
+        WellKnownOpenIDConfigurationResponse response = GsonFactory.getDefaultInstance().fromString(JSON_FROM_GOOGLE, WellKnownOpenIDConfigurationResponse.class);
 
         assertThat(response.getAuthorizationEndpoint(), is("https://accounts.google.com/o/oauth2/v2/auth"));
         assertThat(response.getTokenEndpoint(), is("https://www.googleapis.com/oauth2/v4/token"));
@@ -81,7 +78,7 @@ public class WellKnownOpenIDConfigurationResponseTest {
 
     @Test
     public void parseWellKnownKeys() throws IOException {
-        WellKnownOpenIDConfigurationResponse response = jsonFactory.fromString(JSON_FROM_GOOGLE, WellKnownOpenIDConfigurationResponse.class);
+        WellKnownOpenIDConfigurationResponse response = GsonFactory.getDefaultInstance().fromString(JSON_FROM_GOOGLE, WellKnownOpenIDConfigurationResponse.class);
         assertThat(response.getKnownKeys().keySet(), containsInAnyOrder(
             "authorization_endpoint",
             "token_endpoint",


### PR DESCRIPTION
In 2.6, introduction of group field splitting caused a regression when loading config from XML (see #236).

At the same time, deprecating usage of Jackson2 for using GSon everywhere since it is used by google api.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```