### PR TITLE
Use JMESPath for extracting idtoken and userinfo fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ for a minimal configuration example: 
 
 ![global-config](/docs/images/global-config.png)
 
+All of the fields can be configured as a [JMES Path](https://jmespath.org/) specification.
+Most of the time, the name of the field in the idtoken or userinfo is enough.
+
 #### Using g-suite / google
 
 Obtain the client id and secret from the developer console:

--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,9 @@
       <artifactId>mailer</artifactId>
       <version>1.34.2</version>
     </dependency>
-	<dependency>
-	  <groupId>io.burt</groupId>
-	  <artifactId>jmespath-core</artifactId>
+    <dependency>
+      <groupId>io.burt</groupId>
+      <artifactId>jmespath-core</artifactId>
       <version>0.6.0</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <connection>scm:git:ssh://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com/${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
-    <tag>oic-auth-3.0</tag>
+    <tag>${revision}.${changelist}</tag>
   </scm>
 
   <name>OpenId Connect Authentication Plugin</name>
@@ -70,6 +70,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
       <version>1.34.2</version>
+    </dependency>
+	<dependency>
+	  <groupId>io.burt</groupId>
+	  <artifactId>jmespath-core</artifactId>
+      <version>0.6.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -232,7 +232,7 @@ public class OicSecurityRealm extends SecurityRealm {
         this.setScopes(scopes);
         this.endSessionEndpoint = endSessionEndpoint;
 
-        if("auto".equals(automanualconfigure) ||
+        if ("auto".equals(automanualconfigure) ||
            (Util.fixNull(automanualconfigure).isEmpty() &&
            !Util.fixNull(wellKnownOpenIDConfigurationUrl).isEmpty())) {
             this.automanualconfigure = "auto";
@@ -280,10 +280,10 @@ public class OicSecurityRealm extends SecurityRealm {
     }
 
     protected Object readResolve() {
-        if(httpTransport==null) {
+        if (httpTransport==null) {
             httpTransport = constructHttpTransport(isDisableSslVerification());
         }
-        if(!Strings.isNullOrEmpty(endSessionUrl)) {
+        if (!Strings.isNullOrEmpty(endSessionUrl)) {
             try {
                 Field field = getClass().getDeclaredField("endSessionEndpoint");
                 field.setAccessible(true);
@@ -294,9 +294,9 @@ public class OicSecurityRealm extends SecurityRealm {
         }
 
         // backward compatibility with wrong groupsFieldName split
-        if(Strings.isNullOrEmpty(this.groupsFieldName) && !Strings.isNullOrEmpty(this.simpleGroupsFieldName)) {
+        if (Strings.isNullOrEmpty(this.groupsFieldName) && !Strings.isNullOrEmpty(this.simpleGroupsFieldName)) {
             String originalGroupFieldName = this.simpleGroupsFieldName;
-            if(!Strings.isNullOrEmpty(this.nestedGroupFieldName)) {
+            if (!Strings.isNullOrEmpty(this.nestedGroupFieldName)) {
                 originalGroupFieldName += "[]." + this.nestedGroupFieldName;
             }
             this.setGroupsFieldName(originalGroupFieldName);
@@ -514,7 +514,7 @@ public class OicSecurityRealm extends SecurityRealm {
 
     @DataBoundSetter
     public void setWellKnownOpenIDConfigurationUrl(String wellKnownOpenIDConfigurationUrl) {
-        if( this.isAutoConfigure() ||
+        if ( this.isAutoConfigure() ||
            (this.automanualconfigure.isEmpty() &&
            !Util.fixNull(wellKnownOpenIDConfigurationUrl).isEmpty())) {
             this.automanualconfigure = "auto";
@@ -527,11 +527,11 @@ public class OicSecurityRealm extends SecurityRealm {
     }
 
     private void applyOverrideScopes() {
-        if(!"auto".equals(this.automanualconfigure) || this.overrideScopes == null) {
+        if (!"auto".equals(this.automanualconfigure) || this.overrideScopes == null) {
             // only applies in "auto" mode when overrideScopes defined
             return;
         }
-        if(this.scopes == null) {
+        if (this.scopes == null) {
             this.scopes = overrideScopes;
             return;
         }
@@ -570,18 +570,23 @@ public class OicSecurityRealm extends SecurityRealm {
         this.emailFieldExpr = compileJMESPath(this.emailFieldName, "email field");
     }
 
-    static
-    protected Expression<Object> compileJMESPath(String str, String logComment) {
+    protected static Expression<Object> compileJMESPath(String str, String logComment) {
         if (str == null) {
             return null;
         }
 
-        Expression<Object> expr = JMESPATH.compile(str);
-        if (expr == null && logComment != null) {
-            LOGGER.warning(logComment + " with config '" + str + "' is an invalid JMESPath expression ");
+        try {
+            Expression<Object> expr = JMESPATH.compile(str);
+            if (expr == null && logComment != null) {
+                LOGGER.warning(logComment + " with config '" + str + "' is an invalid JMESPath expression ");
+            }
+            return expr;
+        } catch (RuntimeException e) {
+            if (logComment != null) {
+                LOGGER.warning(logComment + " config failed " + e.toString());
+            }
         }
-
-        return expr;
+        return null;
     }
 
     private Object applyJMESPath(Expression<Object> expression, GenericJson json) {
@@ -631,7 +636,7 @@ public class OicSecurityRealm extends SecurityRealm {
 
     @DataBoundSetter
     public void setOverrideScopesDefined(boolean overrideScopesDefined) {
-        if(overrideScopesDefined) {
+        if (overrideScopesDefined) {
             this.overrideScopesDefined = Boolean.TRUE;
         } else {
             this.overrideScopesDefined = Boolean.FALSE;
@@ -642,7 +647,7 @@ public class OicSecurityRealm extends SecurityRealm {
 
     @DataBoundSetter
     public void setOverrideScopes(String overrideScopes) {
-        if(this.overrideScopesDefined == null || this.overrideScopesDefined) {
+        if (this.overrideScopesDefined == null || this.overrideScopesDefined) {
             this.overrideScopes = Util.fixEmptyAndTrim(overrideScopes);
             this.applyOverrideScopes();
         }
@@ -696,11 +701,11 @@ public class OicSecurityRealm extends SecurityRealm {
 
                         if (authentication instanceof UsernamePasswordAuthenticationToken && escapeHatchEnabled) {
                             randomWait(); // to slowdown brute forcing
-                            if( authentication.getPrincipal().toString().equals(escapeHatchUsername) &&
+                            if ( authentication.getPrincipal().toString().equals(escapeHatchUsername) &&
                                 authentication.getCredentials().toString().equals(Secret.toString(escapeHatchSecret))) {
                                     List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
                                     grantedAuthorities.add(SecurityRealm.AUTHENTICATED_AUTHORITY2);
-                                    if(isNotBlank(escapeHatchGroup)) {
+                                    if (isNotBlank(escapeHatchGroup)) {
                                         grantedAuthorities.add(new SimpleGrantedAuthority(escapeHatchGroup));
                                     }
                                     UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
@@ -763,7 +768,7 @@ public class OicSecurityRealm extends SecurityRealm {
         )
             .setScopes(Arrays.asList(this.getScopes()));
 
-        if(pkceEnabled) {
+        if (pkceEnabled) {
             builder.enablePKCE();
         }
 
@@ -826,7 +831,7 @@ public class OicSecurityRealm extends SecurityRealm {
                         return HttpResponses.errorWithoutStack(401, "Unauthorized");
                     }
 
-                    if(failedCheckOfTokenField(idToken)) {
+                    if (failedCheckOfTokenField(idToken)) {
                         return HttpResponses.errorWithoutStack(401, "Unauthorized");
                     }
 
@@ -838,7 +843,7 @@ public class OicSecurityRealm extends SecurityRealm {
                     }
 
                     String username = determineStringField(userNameFieldExpr, idToken, userInfo);
-                    if(username == null) {
+                    if (username == null) {
                         return HttpResponses.error(500,"no field '" + userNameField + "' was supplied in the UserInfo or the IdToken payload to be used as the username");
                     }
 
@@ -892,17 +897,17 @@ public class OicSecurityRealm extends SecurityRealm {
     }
 
     private boolean failedCheckOfTokenField(IdToken idToken) {
-        if( tokenFieldToCheckKey == null ||
+        if ( tokenFieldToCheckKey == null ||
             tokenFieldToCheckValue == null) {
             return false;
         }
 
-        if(idToken == null) {
+        if (idToken == null) {
             return true;
         }
 
         String value = getStringField(idToken.getPayload(), tokenFieldToCheckExpr);
-        if(value == null) {
+        if (value == null) {
             return true;
         }
 
@@ -912,7 +917,7 @@ public class OicSecurityRealm extends SecurityRealm {
     private UsernamePasswordAuthenticationToken loginAndSetUserData(String userName, IdToken idToken, GenericJson userInfo) throws IOException {
 
         List<GrantedAuthority> grantedAuthorities = determineAuthorities(idToken, userInfo);
-        if(LOGGER.isLoggable(Level.FINEST)) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
             StringBuilder grantedAuthoritiesAsString = new StringBuilder(userName);
             grantedAuthoritiesAsString.append(" (");
             for(GrantedAuthority grantedAuthority : grantedAuthorities) {
@@ -927,7 +932,7 @@ public class OicSecurityRealm extends SecurityRealm {
         SecurityContextHolder.getContext().setAuthentication(token);
 
         User user = User.get2(token);
-        if(user == null){
+        if (user == null){
             // should not happen
             throw new IOException("Cannot set OIDC property on anonymous user");
         }
@@ -972,9 +977,9 @@ public class OicSecurityRealm extends SecurityRealm {
     }
 
     protected String getStringField(Object object, Expression<Object> fieldExpr) {
-        if( object != null && fieldExpr != null) {
+        if ( object != null && fieldExpr != null) {
             Object value = fieldExpr.search(object);
-            if( (value != null) &&
+            if ( (value != null) &&
                 !(value instanceof Map) &&
                 !(value instanceof List)) {
                 return String.valueOf(value);
@@ -988,7 +993,7 @@ public class OicSecurityRealm extends SecurityRealm {
         List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
         grantedAuthorities.add(SecurityRealm.AUTHENTICATED_AUTHORITY2);
         if (this.groupsFieldExpr == null) {
-            if(this.groupsFieldName == null) {
+            if (this.groupsFieldName == null) {
                 LOGGER.fine("Not adding groups because groupsFieldName is not set. groupsFieldName=" + groupsFieldName);
             } else {
                 LOGGER.fine("Not adding groups because groupsFieldName is invalid. groupsFieldName=" + groupsFieldName);
@@ -999,19 +1004,19 @@ public class OicSecurityRealm extends SecurityRealm {
         Object groupsObject = null;
 
         // userInfo has precedence when available
-        if(userInfo != null) {
+        if (userInfo != null) {
             groupsObject = this.groupsFieldExpr.search(userInfo);
         }
-        if(groupsObject == null && idToken != null) {
+        if (groupsObject == null && idToken != null) {
             groupsObject = this.groupsFieldExpr.search(idToken.getPayload());
         }
-        if(groupsObject == null) {
+        if (groupsObject == null) {
             LOGGER.warning("idToken and userInfo did not contain group field name: " + this.groupsFieldName);
             return grantedAuthorities;
         }
 
         List<String> groupNames = ensureString(groupsObject);
-        if(groupNames.isEmpty()){
+        if (groupNames.isEmpty()){
             LOGGER.warning("Could not identify groups in " + groupsFieldName + "=" + groupsObject.toString());
             return grantedAuthorities;
         }
@@ -1072,7 +1077,7 @@ public class OicSecurityRealm extends SecurityRealm {
     @Restricted(DoNotUse.class) // stapler only
     public void doLogout(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         OicSession oicSession = OicSession.getCurrent();
-        if(oicSession!=null) {
+        if (oicSession!=null) {
             // session will be invalidated but we still need this data for our redirect.
             req.setAttribute(ID_TOKEN_REQUEST_ATTRIBUTE, oicSession.getIdToken());
             req.setAttribute(STATE_REQUEST_ATTRIBUTE, oicSession.getState());
@@ -1131,7 +1136,7 @@ public class OicSecurityRealm extends SecurityRealm {
     */
     public HttpResponse doFinishLogin(StaplerRequest request) throws IOException {
         OicSession currentSession = OicSession.getCurrent();
-        if(currentSession==null) {
+        if (currentSession==null) {
             LOGGER.fine("No session to resume (perhaps jenkins was restarted?)");
             return HttpResponses.errorWithoutStack(401, "Unauthorized");
         }
@@ -1186,7 +1191,7 @@ public class OicSecurityRealm extends SecurityRealm {
                 WellKnownOpenIDConfigurationResponse config = GsonFactory.getDefaultInstance()
                         .fromInputStream(response.getContent(), Charset.defaultCharset(),
                                 WellKnownOpenIDConfigurationResponse.class);
-                if(config.getAuthorizationEndpoint() == null || config.getTokenEndpoint() == null) {
+                if (config.getAuthorizationEndpoint() == null || config.getTokenEndpoint() == null) {
                     return FormValidation.warning(Messages.OicSecurityRealm_URLNotAOpenIdEnpoint());
                 }
 
@@ -1241,21 +1246,12 @@ public class OicSecurityRealm extends SecurityRealm {
         }
 
         @RequirePOST
-        public FormValidation doCheckUserNameField(@QueryParameter String userNameField) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            if (Util.fixEmptyAndTrim(userNameField) == null) {
-                return FormValidation.ok(Messages.OicSecurityRealm_UsingDefaultUsername());
-            }
-            return FormValidation.ok();
-        }
-
-        @RequirePOST
         public FormValidation doCheckScopes(@QueryParameter String scopes) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             if (Util.fixEmptyAndTrim(scopes) == null) {
                 return FormValidation.ok(Messages.OicSecurityRealm_UsingDefaultScopes());
             }
-            if(!scopes.toLowerCase().contains("openid")) {
+            if (!scopes.toLowerCase().contains("openid")) {
                 return FormValidation.warning(Messages.OicSecurityRealm_RUSureOpenIdNotInScope());
             }
             return FormValidation.ok();
@@ -1267,7 +1263,7 @@ public class OicSecurityRealm extends SecurityRealm {
             if (Util.fixEmptyAndTrim(overrideScopes) == null) {
                 return FormValidation.ok(Messages.OicSecurityRealm_UsingDefaultScopes());
             }
-            if(!overrideScopes.toLowerCase().contains("openid")) {
+            if (!overrideScopes.toLowerCase().contains("openid")) {
                 return FormValidation.warning(Messages.OicSecurityRealm_RUSureOpenIdNotInScope());
             }
             return FormValidation.ok();
@@ -1303,17 +1299,38 @@ public class OicSecurityRealm extends SecurityRealm {
         }
 
         @RequirePOST
-        // method to check groupsFieldName matches the required format
-        // can contain the substring "[]." at most once.
-        // e.g. "groups", "groups[].name" are valid
-        // groups[].name[].id is not valid
+        public FormValidation doCheckUserNameField(@QueryParameter String userNameField) {
+            return this.doCheckFieldName(userNameField, FormValidation.ok(Messages.OicSecurityRealm_UsingDefaultUsername()));
+        }
+
+        @RequirePOST
+        public FormValidation doCheckFullNameFieldName(@QueryParameter String fullNameFieldName) {
+            return this.doCheckFieldName(fullNameFieldName, FormValidation.ok());
+        }
+
+        @RequirePOST
+        public FormValidation doCheckEmailFieldName(@QueryParameter String emailFieldName) {
+            return this.doCheckFieldName(emailFieldName, FormValidation.ok());
+        }
+
+        @RequirePOST
         public FormValidation doCheckGroupsFieldName(@QueryParameter String groupsFieldName) {
+            return this.doCheckFieldName(groupsFieldName, FormValidation.ok());
+        }
+
+        @RequirePOST
+        public FormValidation doCheckTokenFieldToCheckKey(@QueryParameter String tokenFieldToCheckKey) {
+            return this.doCheckFieldName(tokenFieldToCheckKey, FormValidation.ok());
+        }
+
+        // method to check fieldName matches JMESPath format
+        private FormValidation doCheckFieldName(String fieldName, FormValidation validIfNull) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            if (Util.fixEmptyAndTrim(groupsFieldName) == null) {
-                return FormValidation.ok();
+            if (Util.fixEmptyAndTrim(fieldName) == null) {
+                return validIfNull;
             }
-            if (groupsFieldName.split("\\[\\]\\.").length > 2) {
-                return FormValidation.error(Messages.OicSecurityRealm_InvalidGroupsFieldName());
+            if (OicSecurityRealm.compileJMESPath(fieldName, null) == null) {
+                return FormValidation.error(Messages.OicSecurityRealm_InvalidFieldName());
             }
             return FormValidation.ok();
         }

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -893,13 +893,13 @@ public class OicSecurityRealm extends SecurityRealm {
 
     private boolean failedCheckOfTokenField(IdToken idToken) {
         if( tokenFieldToCheckKey == null ||
-			tokenFieldToCheckValue == null) {
+            tokenFieldToCheckValue == null) {
             return false;
         }
 
-		if(idToken == null) {
+        if(idToken == null) {
             return true;
-		}
+        }
 
         String value = getStringField(idToken.getPayload(), tokenFieldToCheckExpr);
         if(value == null) {
@@ -975,8 +975,8 @@ public class OicSecurityRealm extends SecurityRealm {
         if( object != null && fieldExpr != null) {
             Object value = fieldExpr.search(object);
             if( (value != null) &&
-				!(value instanceof Map) &&
-				!(value instanceof List)) {
+                !(value instanceof Map) &&
+                !(value instanceof List)) {
                 return String.valueOf(value);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/oic/OicUserDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicUserDetails.java
@@ -52,5 +52,4 @@ public class OicUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
-
 }

--- a/src/main/resources/org/jenkinsci/plugins/oic/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/oic/Messages.properties
@@ -16,4 +16,4 @@ OicSecurityRealm.UsingDefaultUsername = Using ''sub''.
 OicSecurityRealm.UsingDefaultScopes = Using ''openid email''.
 OicSecurityRealm.RUSureOpenIdNotInScope = Are you sure you don''t want to include ''openid'' as an scope?
 OicSecurityRealm.EndSessionURLKeyRequired = End Session URL Key is required.
-OicSecurityRealm.InvalidGroupsFieldName = Invalid groups field name - may only contain letters, numbers, and underscores and one instance of [].
+OicSecurityRealm.InvalidFieldName = Invalid field name - must be a valid JMESPath expression.

--- a/src/main/resources/org/jenkinsci/plugins/oic/Messages_zh.properties
+++ b/src/main/resources/org/jenkinsci/plugins/oic/Messages_zh.properties
@@ -16,4 +16,3 @@ OicSecurityRealm.UsingDefaultUsername = \u4f7f\u7528 sub
 OicSecurityRealm.UsingDefaultScopes = \u4f7f\u7528 openid \u96fb\u5b50\u4fe1\u7bb1
 OicSecurityRealm.RUSureOpenIdNotInScope = \u662f\u5426\u78ba\u8a8d\u4e0d\u5c07 \u300copenid\u300d\u4f5c\u70ba\u4e00\u500b\u7bc4\u570d scope \uff1f
 OicSecurityRealm.EndSessionURLKeyRequired = \u9700\u8981\u63d0\u4f9b\u7d42\u6b62 Session \u4e4b Url \u91d1\u9470
-OicSecurityRealm.InvalidGroupsFieldName = \u7121\u6548\u7684\u7fa4\u7d44\u6b04\u4f4d\u540d\u7a31 - \u53ea\u80fd\u5305\u542b\u5b57\u6bcd\u3001\u6578\u5b57\u3001\u5e95\u7dda\u548c\u4e00\u500b [] \u5be6\u4f8b

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-groupsFieldName.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-groupsFieldName.html
@@ -1,8 +1,11 @@
 <div>
-    Not required. If the field exists in the token and is an array of strings, then each string is added as a group.
+    Not required. The field specification must be a valid <a href="https://jmespath.org/" target="_blank">JMES Path</a>.
+
+    If the field exists in the token and is an array of strings, then each string is added as a group.
     This allows groups based authorization in Jenkins. The SSO server will need to add the field with the list of groups in 
     the token. For example in Keycloak, this can be done with a 'Group Membership' mapper in the configuration of the client.
 
-    If the SSO server adds the groups as an array of maps instead, then specify the group field as "groups[].name" where "groups"
+    But if, by example, the SSO server adds the groups as an array of maps instead, then specify the group field as "groups[].name" where "groups"
     is the field containing the array of maps, and "name" it the name of the key in the map that holds the group name.
+
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-tokenFieldToCheckKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/help-tokenFieldToCheckKey.html
@@ -1,4 +1,5 @@
 <div>
-    Optional. The name of the field to check.
+    Optional. The name of the field to chek, which must be a valid <a href="https://jmespath.org/" target="_blank">JMES Path</a>.
+
     If specified, users are required to have this field match the value to successfully login
 </div>

--- a/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
@@ -60,7 +60,7 @@ public class ConfigurationAsCodeTest {
         assertEquals("http://localhost", oicSecurityRealm.getTokenServerUrl());
         assertEquals(TokenAuthMethod.client_secret_post, oicSecurityRealm.getTokenAuthMethod());
         assertEquals("userNameField", oicSecurityRealm.getUserNameField());
-    assertTrue(oicSecurityRealm.isRootURLFromRequest());
+		assertTrue(oicSecurityRealm.isRootURLFromRequest());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
@@ -60,7 +60,7 @@ public class ConfigurationAsCodeTest {
         assertEquals("http://localhost", oicSecurityRealm.getTokenServerUrl());
         assertEquals(TokenAuthMethod.client_secret_post, oicSecurityRealm.getTokenAuthMethod());
         assertEquals("userNameField", oicSecurityRealm.getUserNameField());
-		assertTrue(oicSecurityRealm.isRootURLFromRequest());
+        assertTrue(oicSecurityRealm.isRootURLFromRequest());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/oic/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/DescriptorImplTest.java
@@ -126,12 +126,64 @@ public class DescriptorImplTest {
         TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
 
         OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
-
         assertNotNull(descriptor);
+
         assertEquals(FormValidation.ok("Using 'sub'.").getMessage(),
             descriptor.doCheckUserNameField(null).getMessage());
         assertEquals(FormValidation.ok("Using 'sub'.").getMessage(), descriptor.doCheckUserNameField("").getMessage());
-        assertEquals(FormValidation.ok(), descriptor.doCheckUserNameField("http://localhost"));
+        assertEquals(FormValidation.ok(), descriptor.doCheckUserNameField("subfield"));
+    }
+
+    @Test
+    public void doCheckFullNameFieldName() throws IOException {
+        configureWellKnown();
+        TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
+
+        OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
+        assertNotNull(descriptor);
+
+        assertEquals(FormValidation.ok(), descriptor.doCheckFullNameFieldName(""));
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckFullNameFieldName("]not valid").kind);
+        assertEquals(FormValidation.ok(), descriptor.doCheckFullNameFieldName("myname"));
+    }
+
+    @Test
+    public void doCheckEmailFieldName() throws IOException {
+        configureWellKnown();
+        TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
+
+        OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
+        assertNotNull(descriptor);
+
+        assertEquals(FormValidation.ok(), descriptor.doCheckEmailFieldName(""));
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckEmailFieldName("]not valid").kind);
+        assertEquals(FormValidation.ok(), descriptor.doCheckEmailFieldName("myemail"));
+    }
+
+    @Test
+    public void doCheckGroupsFieldName() throws IOException {
+        configureWellKnown();
+        TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
+
+        OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
+        assertNotNull(descriptor);
+
+        assertEquals(FormValidation.ok(), descriptor.doCheckGroupsFieldName(""));
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckGroupsFieldName("]not valid").kind);
+        assertEquals(FormValidation.ok(), descriptor.doCheckGroupsFieldName("mygroups"));
+    }
+
+    @Test
+    public void doCheckTokenFieldToCheckKey() throws IOException {
+        configureWellKnown();
+        TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
+
+        OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
+        assertNotNull(descriptor);
+
+        assertEquals(FormValidation.ok(), descriptor.doCheckTokenFieldToCheckKey(""));
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckTokenFieldToCheckKey("]not valid").kind);
+        assertEquals(FormValidation.ok(), descriptor.doCheckTokenFieldToCheckKey("akey"));
     }
 
     @Test
@@ -140,8 +192,8 @@ public class DescriptorImplTest {
         TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
 
         OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
-
         assertNotNull(descriptor);
+
         assertEquals(FormValidation.ok("Using 'openid email'.").getMessage(),
             descriptor.doCheckScopes(null).getMessage());
         assertEquals(FormValidation.ok("Using 'openid email'.").getMessage(),
@@ -160,8 +212,8 @@ public class DescriptorImplTest {
         TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
 
         OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
-
         assertNotNull(descriptor);
+
         assertEquals("End Session URL Key is required.",
             descriptor.doCheckEndSessionEndpoint(null).getMessage());
         assertEquals("End Session URL Key is required.",
@@ -176,8 +228,8 @@ public class DescriptorImplTest {
         TestRealm realm = new TestRealm(wireMockRule, null, null, null, AUTO_CONFIG_FIELD);
 
         OicSecurityRealm.DescriptorImpl descriptor = (DescriptorImpl) realm.getDescriptor();
-
         assertNotNull(descriptor);
+
         assertEquals(FormValidation.ok(), descriptor.doCheckPostLogoutRedirectUrl(null));
         assertEquals(FormValidation.ok(), descriptor.doCheckPostLogoutRedirectUrl(""));
         assertTrue(descriptor.doCheckPostLogoutRedirectUrl("not a url").getMessage().contains("Not a valid url."));

--- a/src/test/java/org/jenkinsci/plugins/oic/FieldTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/FieldTest.java
@@ -8,8 +8,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -75,5 +73,15 @@ public class FieldTest {
         TestRealm realm = new TestRealm(wireMockRule);
 
         assertEquals("john dow", realm.getStringFieldFromJMESPath(payload, "[user.name, user.surname] | join(' ', @)"));
+    }
+
+    @Test
+    public void testInvalidFieldName() throws Exception {
+        GenericJson payload = new GenericJson();
+        payload.put("user", "john");
+
+        TestRealm realm = new TestRealm(wireMockRule);
+
+        assertNull(realm.getStringFieldFromJMESPath(payload, "[user)"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/FieldTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/FieldTest.java
@@ -61,4 +61,19 @@ public class FieldTest {
         assertEquals("myusername", realm.getStringFieldFromJMESPath(payload, "\"user.name\""));
         assertNull(realm.getStringFieldFromJMESPath(payload, "none"));
     }
+
+    @Test
+    public void testFieldProcessing() throws Exception {
+        HashMap<String, Object> user = new HashMap<>();
+        user.put("id", "100");
+        user.put("name", "john");
+        user.put("surname", "dow");
+
+        GenericJson payload = new GenericJson();
+        payload.put("user", user);
+
+        TestRealm realm = new TestRealm(wireMockRule);
+
+        assertEquals("john dow", realm.getStringFieldFromJMESPath(payload, "[user.name, user.surname] | join(' ', @)"));
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/FieldTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/FieldTest.java
@@ -33,19 +33,12 @@ public class FieldTest {
 
         TestRealm realm = new TestRealm(wireMockRule);
 
-        assertEquals("myemail@example.com", realm.getField(payload, "email"));
-        assertEquals("100", realm.getField(payload, "user.id"));
-        assertNull(realm.getField(payload, "unknown"));
-        assertNull(realm.getField(payload, "user"));
-        assertNull(realm.getField(payload, "user.invalid"));
-        assertNull(realm.getField(payload, "none"));
-
-        assertTrue(realm.containsField(payload, "email"));
-        assertTrue(realm.containsField(payload, "user.id"));
-        assertFalse(realm.containsField(payload, "unknown"));
-        assertFalse(realm.containsField(payload, "user"));
-        assertFalse(realm.containsField(payload, "user.invalid"));
-        assertTrue(realm.containsField(payload, "none"));
+        assertEquals("myemail@example.com", realm.getStringFieldFromJMESPath(payload, "email"));
+        assertEquals("100", realm.getStringFieldFromJMESPath(payload, "user.id"));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "unknown"));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "user"));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "user.invalid"));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "none"));
     }
 
     @Test
@@ -61,18 +54,11 @@ public class FieldTest {
 
         TestRealm realm = new TestRealm(wireMockRule);
 
-        assertEquals("myemail@example.com", realm.getField(payload, "email"));
-        assertNull(realm.getField(payload, "unknown"));
-        assertNull(realm.getField(payload, "user"));
-        assertNull(realm.getField(payload, "user.invalid"));
-        assertEquals("myusername", realm.getField(payload, "user.name"));
-        assertNull(realm.getField(payload, "none"));
-
-        assertTrue(realm.containsField(payload, "email"));
-        assertFalse(realm.containsField(payload, "unknown"));
-        assertFalse(realm.containsField(payload, "user"));
-        assertFalse(realm.containsField(payload, "user.invalid"));
-        assertTrue(realm.containsField(payload, "none"));
-        assertTrue(realm.containsField(payload, "user.name"));
+        assertEquals("myemail@example.com", realm.getStringFieldFromJMESPath(payload, "email"));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "unknown"));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "user"));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "user.invalid"));
+        assertEquals("myusername", realm.getStringFieldFromJMESPath(payload, "\"user.name\""));
+        assertNull(realm.getStringFieldFromJMESPath(payload, "none"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.oic;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import hudson.model.Descriptor;
 import hudson.security.SecurityRealm;
+import io.burt.jmespath.Expression;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import org.kohsuke.stapler.HttpResponse;
@@ -165,6 +166,14 @@ public class TestRealm extends OicSecurityRealm {
         }
         return super.doFinishLogin(request);
     }
+
+	public String getStringFieldFromJMESPath(Object object, String jmespathField) {
+		Expression<Object> expr = super.compileJMESPath(jmespathField, "test field");
+		if (expr == null) {
+			return null;
+		}
+		return super.getStringField(object, expr);
+	}
 
     @Override
     public Object readResolve() {

--- a/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
@@ -167,13 +167,13 @@ public class TestRealm extends OicSecurityRealm {
         return super.doFinishLogin(request);
     }
 
-	public String getStringFieldFromJMESPath(Object object, String jmespathField) {
-		Expression<Object> expr = super.compileJMESPath(jmespathField, "test field");
-		if (expr == null) {
-			return null;
-		}
-		return super.getStringField(object, expr);
-	}
+    public String getStringFieldFromJMESPath(Object object, String jmespathField) {
+        Expression<Object> expr = super.compileJMESPath(jmespathField, "test field");
+        if (expr == null) {
+            return null;
+        }
+        return super.getStringField(object, expr);
+    }
 
     @Override
     public Object readResolve() {


### PR DESCRIPTION
Replace hand made field path with [JMESPath ](https://jmespath.org/) expression library (#149).

This introduces a new dependency on [burtcorp/jmespath-java](https://github.com/burtcorp/jmespath-java) but provides better path capacity. In particular, it provides support for concatenating fields (#256) and open the possibility to have special processing functions such as regex (#128).

This introduces a minor break of configuration in the case a field name contains a dot. In the previous implementation an `field.name` would be foud, with JMES Path, the name of the field must quoted: `"field.name"`.

### Testing done

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
