### PR TITLE
Hash escape hatch password in configuration - fix CVE-2023-50770

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicSecurityRealm/config.jelly
@@ -89,7 +89,7 @@
     <f:entry title="${%Post logout redirect URL}" field="postLogoutRedirectUrl">
       <f:textbox/>
     </f:entry>
-    <f:entry title="${%Enable Proof Key for Code Exchang (PKCE)}" field="pkceEnabled">
+    <f:entry title="${%Enable Proof Key for Code Exchange (PKCE)}" field="pkceEnabled">
       <f:checkbox/>
     </f:entry>
     <f:entry title="${%Disable Nonce verification}" field="nonceDisabled">

--- a/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
@@ -51,7 +51,7 @@ public class ConfigurationAsCodeTest {
         assertEquals("emailFieldName", oicSecurityRealm.getEmailFieldName());
         assertTrue(oicSecurityRealm.isEscapeHatchEnabled());
         assertEquals("escapeHatchGroup", oicSecurityRealm.getEscapeHatchGroup());
-        assertEquals("escapeHatchSecret", Secret.toString(oicSecurityRealm.getEscapeHatchSecret()));
+        assertEquals("$2a$10$fxteEkfDqwqkmUelZmTxlu9WESjVDKQhp6jsqB1AgsLQ2dC6jikga", Secret.toString(oicSecurityRealm.getEscapeHatchSecret()));
         assertEquals("escapeHatchUsername", oicSecurityRealm.getEscapeHatchUsername());
         assertEquals("fullNameFieldName", oicSecurityRealm.getFullNameFieldName());
         assertEquals("groupsFieldName", oicSecurityRealm.getGroupsFieldName());

--- a/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/TestRealm.java
@@ -179,4 +179,8 @@ public class TestRealm extends OicSecurityRealm {
     public Object readResolve() {
         return super.readResolve();
     }
+
+    public boolean doCheckEscapeHatch(String username, String password) {
+        return super.checkEscapeHatch(username, password);
+    }
 }

--- a/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
+++ b/src/test/resources/org/jenkinsci/plugins/oic/ConfigurationAsCode.yml
@@ -8,7 +8,7 @@ jenkins:
       emailFieldName: emailFieldName
       escapeHatchEnabled: true
       escapeHatchGroup: escapeHatchGroup
-      escapeHatchSecret: escapeHatchSecret
+      escapeHatchSecret: "$2a$10$fxteEkfDqwqkmUelZmTxlu9WESjVDKQhp6jsqB1AgsLQ2dC6jikga"
       escapeHatchUsername: escapeHatchUsername
       fullNameFieldName: fullNameFieldName
       groupsFieldName: groupsFieldName


### PR DESCRIPTION
Store hashed password with salt in configuration to avoid recoverable format (see [SECURITY-3168 / CVE-2023-50770](https://www.jenkins.io/security/advisory/2023-12-13/#SECURITY-3168)).
The hashing uses BCrypt as indicated in [SECURITY-3168](https://issues.jenkins.io/browse/SECURITY-3168).

Resolve open vulnerability as requested in #259.

### Testing done

Testing of in unit test for JasC configuration. Secret migration perfomed by hand by checking the configuration has changed after reload.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
