### PR TITLE
Compatibility with Jenkins clustered setup

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/oic/OicSessionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSessionTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.oic;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import java.io.IOException;
 import jenkins.model.Jenkins;
 import org.junit.Before;
@@ -28,9 +29,9 @@ public class OicSessionTest {
         .WithMinimalDefaults().WithScopes("openid")
         .build();
 
-    session = new OicSession(realm.buildAuthorizationCodeFlow(), from, buildOAuthRedirectUrl()) {
+    session = new OicSession(from, buildOAuthRedirectUrl()) {
             @Override
-            public HttpResponse onSuccess(String authorizationCode) {
+            public HttpResponse onSuccess(String authorizationCode, AuthorizationCodeFlow flow) {
                 return null;
             }
         };


### PR DESCRIPTION
`OicSession` is stored in HTTP session so must be serializable. As it is, `OicSecurityRealm` must also be `Serializable` since it defines a non-static inner class extending `OicSession`.

`AuthorizationCodeFlow` is not serializable, so instead of storing it directly in `OicSession`, it is now provided on every call from `OicSecurityRealm` (`commenceLogin`, `finishLogin` `onSuccess`).

Removed `do` prefix from `OicSession#doCommenceLogin`, `OicSession#doFinishLogin` to clarify that these methods are not being called by Stapler, but through direct java calls.

These changes allow to use this plugin as security realm when running a clustered Jenkins instance (where sessions are serialized) such as when using CloudBees CI with High Availability.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
