### PR TITLE
Reimplement PKCE to serialize verifier in session

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -824,10 +824,6 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
                         authorizationServerUrl)
                 .setScopes(Arrays.asList(this.getScopes()));
 
-        if (pkceEnabled) {
-            builder.enablePKCE();
-        }
-
         return builder.build();
     }
 
@@ -867,6 +863,9 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
                     AuthorizationCodeTokenRequest tokenRequest = flow.newTokenRequest(authorizationCode)
                             .setRedirectUri(buildOAuthRedirectUrl())
                             .setResponseClass(OicTokenResponse.class);
+                    if (this.pkceVerifierCode != null) {
+                        tokenRequest.set("code_verifier", this.pkceVerifierCode);
+                    }
                     if (!sendScopesInTokenRequest) {
                         tokenRequest.setScopes(Collections.emptyList());
                     }
@@ -907,7 +906,9 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
                     return HttpResponses.error(500, e);
                 }
             }
-        }.commenceLogin(isNonceDisabled(), buildAuthorizationCodeFlow());
+        }.withNonceDisabled(isNonceDisabled())
+        .withPkceEnabled(isPkceEnabled())
+        .commenceLogin(buildAuthorizationCodeFlow());
     }
 
     @SuppressFBWarnings(

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
@@ -116,7 +116,7 @@ abstract class OicSession implements Serializable {
 
         public PKCE(String verifierCode) {
             try {
-                byte[] bytes = verifierCode.getBytes();
+                byte[] bytes = verifierCode.getBytes(StandardCharsets.UTF_8);
                 MessageDigest md = MessageDigest.getInstance("SHA-256");
                 md.update(bytes, 0, bytes.length);
                 byte[] digest = md.digest();


### PR DESCRIPTION
Persist code verifier in session information in order to  allow HA Jenkins.

Fixes #290 regression: PKCE information was stored in google's AuthorizationCode flow and not serialized into session.
Current google implementation doesn't allow the get/set of verifier code code so, in our case, PKCE can no longer be used from within google flow. Therefore, this change implements PKCE in the plugin.

### Testing done

Unit test now verifies PKCE validity instead of presence only.

Change manually tested with Google, with PKCE activated.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
