### PR TITLE
Bump mailer from 1.34.2 to 448.v5b_97805e3767

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.34.2</version>
+      <version>448.v5b_97805e3767</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>


### PR DESCRIPTION
Align mailer plugin with Jenkins version - same as #200