### PR TITLE
Re-activate spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,13 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <configuration>
           <java combine.self="override">
+            <endWithNewline />
+            <indent>
+              <spaces>true</spaces>
+            </indent>
+            <palantirJavaFormat />
+            <removeUnusedImports />
+            <trimTrailingWhitespace />
             <importOrder>
               <order>,\#</order>
             </importOrder>

--- a/src/main/java/org/jenkinsci/plugins/oic/OicJsonWebTokenVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicJsonWebTokenVerifier.java
@@ -64,14 +64,14 @@ public class OicJsonWebTokenVerifier extends IdTokenVerifier {
         return jwksServerUrlAvailable;
     }
 
-
     /** Verify real idtoken */
     public boolean verifyIdToken(IdToken idToken) throws IOException {
         if (isJwksServerUrlAvailable()) {
             try {
                 return verifyOrThrow(idToken);
-            } catch(IOException e) {
-                LOGGER.warning("IdToken signature verification failed '" + e.toString() + "' - jwks signature verification disabled");
+            } catch (IOException e) {
+                LOGGER.warning("IdToken signature verification failed '" + e.toString()
+                        + "' - jwks signature verification disabled");
                 jwksServerUrlAvailable = false;
             }
         }
@@ -88,7 +88,7 @@ public class OicJsonWebTokenVerifier extends IdTokenVerifier {
                         userinfo.getSignatureBytes(),
                         userinfo.getSignedContentBytes());
                 return verifyOrThrow(idToken);
-            } catch(IOException e) {
+            } catch (IOException e) {
                 LOGGER.warning("UserInfo signature verification failed '" + e.toString() + "' - ignore");
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -270,8 +270,8 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         this.endSessionEndpoint = endSessionEndpoint;
 
         if ("auto".equals(automanualconfigure)
-                || (Util.fixNull(automanualconfigure).isEmpty() &&
-                    !Util.fixNull(wellKnownOpenIDConfigurationUrl).isEmpty())) {
+                || (Util.fixNull(automanualconfigure).isEmpty()
+                        && !Util.fixNull(wellKnownOpenIDConfigurationUrl).isEmpty())) {
             this.automanualconfigure = "auto";
             this.wellKnownOpenIDConfigurationUrl = Util.fixEmptyAndTrim(wellKnownOpenIDConfigurationUrl);
             this.loadWellKnownOpenIDConfigurationUrl();
@@ -748,7 +748,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
 
     @DataBoundSetter
     public void setDisableTokenVerification(boolean disableTokenVerification) {
-        this. disableTokenVerification = disableTokenVerification;
+        this.disableTokenVerification = disableTokenVerification;
     }
 
     @DataBoundSetter
@@ -917,8 +917,8 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
                     }
                     IdToken idToken;
                     try {
-                         idToken = response.parseIdToken();
-                    } catch(IllegalArgumentException e) {
+                        idToken = response.parseIdToken();
+                    } catch (IllegalArgumentException e) {
                         return HttpResponses.errorWithoutStack(403, Messages.OicSecurityRealm_IdTokenParseError());
                     }
                     if (!validateIdToken(idToken)) {
@@ -958,8 +958,8 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
                 }
             }
         }.withNonceDisabled(isNonceDisabled())
-        .withPkceEnabled(isPkceEnabled())
-        .commenceLogin(buildAuthorizationCodeFlow());
+                .withPkceEnabled(isPkceEnabled())
+                .commenceLogin(buildAuthorizationCodeFlow());
     }
 
     /** Create OicJsonWebTokenVerifier if needed */
@@ -970,19 +970,18 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         if (jwtVerifier == null) {
             jwtVerifier = new OicJsonWebTokenVerifier(
                     jwksServerUrl,
-                    new OicJsonWebTokenVerifier.Builder()
-                        .setHttpTransportFactory(new HttpTransportFactory() {
-                            @Override
-                            public HttpTransport create() {
-                                return httpTransport;
-                            }
-                        }));
+                    new OicJsonWebTokenVerifier.Builder().setHttpTransportFactory(new HttpTransportFactory() {
+                        @Override
+                        public HttpTransport create() {
+                            return httpTransport;
+                        }
+                    }));
         }
         return jwtVerifier;
     }
 
     /** Validate UserInfo signature if available */
-    private boolean validateUserInfo(JsonWebSignature userinfo)  throws IOException {
+    private boolean validateUserInfo(JsonWebSignature userinfo) throws IOException {
         OicJsonWebTokenVerifier verifier = getJwksVerifier();
         if (verifier == null) {
             return true;

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
@@ -170,9 +170,8 @@ abstract class OicSession implements Serializable {
      */
     public HttpResponse commenceLogin(AuthorizationCodeFlow flow) {
         setupOicSession(Stapler.getCurrentRequest().getSession());
-        AuthorizationCodeRequestUrl authorizationCodeRequestUrl = flow.newAuthorizationUrl()
-            .setState(state)
-            .setRedirectUri(redirectUrl);
+        AuthorizationCodeRequestUrl authorizationCodeRequestUrl =
+                flow.newAuthorizationUrl().setState(state).setRedirectUri(redirectUrl);
         if (this.nonce != null) {
             authorizationCodeRequestUrl.set("nonce", this.nonce); // no @Key field defined in AuthorizationRequestUrl
         }

--- a/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/ConfigurationAsCodeTest.java
@@ -70,10 +70,8 @@ public class ConfigurationAsCodeTest {
     public void testExport() throws Exception {
         ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
 
-        CNode yourAttribute = getJenkinsRoot(context)
-            .get("securityRealm")
-            .asMapping()
-            .get("oic");
+        CNode yourAttribute =
+                getJenkinsRoot(context).get("securityRealm").asMapping().get("oic");
 
         String exported = toYamlString(yourAttribute);
 

--- a/src/test/java/org/jenkinsci/plugins/oic/OicJsonWebTokenVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicJsonWebTokenVerifierTest.java
@@ -62,18 +62,15 @@ public class OicJsonWebTokenVerifierTest {
         wireMockRule.resetAll();
         IdToken idtoken = createIdToken(keyPair.getPrivate(), new HashMap<>());
         OicJsonWebTokenVerifier verifier = new OicJsonWebTokenVerifier(
-                "http://localhost:" + wireMockRule.port() + "/jwks",
-                new OicJsonWebTokenVerifier.Builder()
-                );
+                "http://localhost:" + wireMockRule.port() + "/jwks", new OicJsonWebTokenVerifier.Builder());
         assertTrue(verifier.isJwksServerUrlAvailable());
 
         wireMockRule.stubFor(get(urlPathEqualTo("/jwks"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"keys\":[{"+encodePublicKey(keyPair)+
-                            ",\"alg\":\"RS256\""+
-                            ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""+
-                            "}]}")));
+                        .withBody("{\"keys\":[{" + encodePublicKey(keyPair) + ",\"alg\":\"RS256\""
+                                + ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""
+                                + "}]}")));
 
         assertTrue(verifier.verifyIdToken(idtoken));
         assertTrue(verifier.isJwksServerUrlAvailable());
@@ -82,10 +79,7 @@ public class OicJsonWebTokenVerifierTest {
     @Test
     public void tesNoJWKSURIShouldBeSuccessfulAndNeverVerifySignature() throws Exception {
         IdToken idtoken = createIdToken(keyPair.getPrivate(), new HashMap<>());
-        OicJsonWebTokenVerifier verifier = new OicJsonWebTokenVerifier(
-                null,
-                new OicJsonWebTokenVerifier.Builder()
-                );
+        OicJsonWebTokenVerifier verifier = new OicJsonWebTokenVerifier(null, new OicJsonWebTokenVerifier.Builder());
         assertFalse(verifier.isJwksServerUrlAvailable());
 
         assertTrue(verifier.verifyIdToken(idtoken));
@@ -96,13 +90,10 @@ public class OicJsonWebTokenVerifierTest {
         wireMockRule.resetAll();
         IdToken idtoken = createIdToken(keyPair.getPrivate(), new HashMap<>());
         OicJsonWebTokenVerifier verifier = new OicJsonWebTokenVerifier(
-                "http://localhost:" + wireMockRule.port() + "/jwks",
-                new OicJsonWebTokenVerifier.Builder()
-                );
+                "http://localhost:" + wireMockRule.port() + "/jwks", new OicJsonWebTokenVerifier.Builder());
         assertTrue(verifier.isJwksServerUrlAvailable());
 
-        wireMockRule.stubFor(get(urlPathEqualTo("/jwks"))
-                .willReturn(aResponse().withStatus(404)));
+        wireMockRule.stubFor(get(urlPathEqualTo("/jwks")).willReturn(aResponse().withStatus(404)));
 
         assertTrue(verifier.verifyIdToken(idtoken));
         assertFalse(verifier.isJwksServerUrlAvailable());
@@ -113,17 +104,14 @@ public class OicJsonWebTokenVerifierTest {
         wireMockRule.resetAll();
         IdToken idtoken = createIdToken(keyPair.getPrivate(), new HashMap<>());
         OicJsonWebTokenVerifier verifier = new OicJsonWebTokenVerifier(
-                "http://localhost:" + wireMockRule.port() + "/jwks",
-                new OicJsonWebTokenVerifier.Builder()
-                );
+                "http://localhost:" + wireMockRule.port() + "/jwks", new OicJsonWebTokenVerifier.Builder());
         assertTrue(verifier.isJwksServerUrlAvailable());
 
         wireMockRule.stubFor(get(urlPathEqualTo("/jwks"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"keys\":[{"+encodePublicKey(keyPair)+
-                            ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""+
-                            "}]}")));
+                        .withBody("{\"keys\":[{" + encodePublicKey(keyPair) + ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""
+                                + "}]}")));
 
         assertTrue(verifier.verifyIdToken(idtoken));
         assertFalse(verifier.isJwksServerUrlAvailable());
@@ -134,24 +122,21 @@ public class OicJsonWebTokenVerifierTest {
         wireMockRule.resetAll();
         IdToken idtoken = createIdToken(keyPair.getPrivate(), new HashMap<>());
         OicJsonWebTokenVerifier verifier = new OicJsonWebTokenVerifier(
-                "http://localhost:" + wireMockRule.port() + "/jwks",
-                new OicJsonWebTokenVerifier.Builder()
-                );
+                "http://localhost:" + wireMockRule.port() + "/jwks", new OicJsonWebTokenVerifier.Builder());
         assertTrue(verifier.isJwksServerUrlAvailable());
 
         wireMockRule.stubFor(get(urlPathEqualTo("/jwks"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"keys\":[{"+encodePublicKey(keyPair)+
-                            ",\"alg\":\"RSA-OAEP\""+
-                            ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""+
-                            "}]}")));
+                        .withBody("{\"keys\":[{" + encodePublicKey(keyPair) + ",\"alg\":\"RSA-OAEP\""
+                                + ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""
+                                + "}]}")));
 
         assertTrue(verifier.verifyIdToken(idtoken));
         assertFalse(verifier.isJwksServerUrlAvailable());
     }
 
-    static private KeyPair createKeyPair() {
+    private static KeyPair createKeyPair() {
         try {
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
             keyGen.initialize(2048);
@@ -163,40 +148,36 @@ public class OicJsonWebTokenVerifierTest {
     }
 
     private IdToken createIdToken(PrivateKey privateKey, Map<String, Object> keyValues) throws Exception {
-        JsonWebSignature.Header header = new JsonWebSignature.Header()
-            .setAlgorithm("RS256")
-            .setKeyId("jwks_key_id");
-        long now = (long)(Clock.SYSTEM.currentTimeMillis()/1000);
+        JsonWebSignature.Header header =
+                new JsonWebSignature.Header().setAlgorithm("RS256").setKeyId("jwks_key_id");
+        long now = (long) (Clock.SYSTEM.currentTimeMillis() / 1000);
         IdToken.Payload payload = new IdToken.Payload()
-            .setExpirationTimeSeconds(now + 60L)
-            .setIssuedAtTimeSeconds(now)
-            .setIssuer("issuer")
-            .setSubject("sub")
-            .setAudience(Collections.singletonList("clientId"))
-            .setNonce("nonce");
+                .setExpirationTimeSeconds(now + 60L)
+                .setIssuedAtTimeSeconds(now)
+                .setIssuer("issuer")
+                .setSubject("sub")
+                .setAudience(Collections.singletonList("clientId"))
+                .setNonce("nonce");
         for (Map.Entry<String, Object> keyValue : keyValues.entrySet()) {
             payload.set(keyValue.getKey(), keyValue.getValue());
         }
 
         JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-        String content =
-            Base64.encodeBase64URLSafeString(jsonFactory.toByteArray(header))
-            + "."
-            + Base64.encodeBase64URLSafeString(jsonFactory.toByteArray(payload));
+        String content = Base64.encodeBase64URLSafeString(jsonFactory.toByteArray(header))
+                + "."
+                + Base64.encodeBase64URLSafeString(jsonFactory.toByteArray(payload));
         byte[] contentBytes = StringUtils.getBytesUtf8(content);
         byte[] signature =
-            SecurityUtils.sign(
-                    SecurityUtils.getSha256WithRsaSignatureAlgorithm(), privateKey, contentBytes);
+                SecurityUtils.sign(SecurityUtils.getSha256WithRsaSignatureAlgorithm(), privateKey, contentBytes);
         return new IdToken(header, payload, signature, contentBytes);
     }
 
     /** Generate JWKS entry with public key of keyPair */
     String encodePublicKey(KeyPair keyPair) {
-        final RSAPublicKey rsaPKey = (RSAPublicKey)(keyPair.getPublic());
-        return "\"n\":\"" +
-            Base64.encodeBase64String(rsaPKey.getModulus().toByteArray()) +
-            "\",\"e\":\"" +
-            Base64.encodeBase64String(rsaPKey.getPublicExponent().toByteArray()) +
-            "\",\"kty\":\"RSA\"";
+        final RSAPublicKey rsaPKey = (RSAPublicKey) (keyPair.getPublic());
+        return "\"n\":\"" + Base64.encodeBase64String(rsaPKey.getModulus().toByteArray())
+                + "\",\"e\":\""
+                + Base64.encodeBase64String(rsaPKey.getPublicExponent().toByteArray())
+                + "\",\"kty\":\"RSA\"";
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -58,7 +58,6 @@ import static org.jenkinsci.plugins.oic.TestRealm.MANUAL_CONFIG_FIELD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-
 /**
  * goes trough a login scenario, the openid provider is mocked and always returns state. We aren't checking
  * if if openid connect or if the openid connect implementation works. Rather we are only
@@ -147,8 +146,7 @@ public class PluginTest {
         verify(getRequestedFor(urlPathEqualTo("/authorization"))
                 .withQueryParam("scope", equalTo("openid email"))
                 .withQueryParam("nonce", matching(".+")));
-        verify(postRequestedFor(urlPathEqualTo("/token"))
-                .withRequestBody(notMatching(".*&scope=.*")));
+        verify(postRequestedFor(urlPathEqualTo("/token")).withRequestBody(notMatching(".*&scope=.*")));
     }
 
     @Test
@@ -184,10 +182,8 @@ public class PluginTest {
         jenkins.setSecurityRealm(oidcSecurityRealm);
         webClient.goTo(jenkins.getSecurityRealm().getLoginUrl());
 
-        verify(getRequestedFor(urlPathEqualTo("/authorization"))
-                .withQueryParam("scope", equalTo("openid email")));
-        verify(postRequestedFor(urlPathEqualTo("/token"))
-                .withRequestBody(containing("&scope=openid+email&")));
+        verify(getRequestedFor(urlPathEqualTo("/authorization")).withQueryParam("scope", equalTo("openid email")));
+        verify(postRequestedFor(urlPathEqualTo("/token")).withRequestBody(containing("&scope=openid+email&")));
     }
 
     @Test
@@ -226,21 +222,20 @@ public class PluginTest {
         verify(getRequestedFor(urlPathEqualTo("/authorization"))
                 .withQueryParam("code_challenge_method", equalTo("S256"))
                 .withQueryParam("code_challenge", matching(".+")));
-        verify(postRequestedFor(urlPathEqualTo("/token"))
-                .withRequestBody(matching(".*&code_verifier=[^&]+.*")));
+        verify(postRequestedFor(urlPathEqualTo("/token")).withRequestBody(matching(".*&code_verifier=[^&]+.*")));
 
         // check PKCE
         //   - get codeChallenge
         final String codeChallenge = findAll(getRequestedFor(urlPathEqualTo("/authorization")))
-            .get(0)
-            .queryParameter("code_challenge")
-            .values()
-            .get(0);
+                .get(0)
+                .queryParameter("code_challenge")
+                .values()
+                .get(0);
         //   - get verifierCode
         Matcher m = Pattern.compile(".*&code_verifier=([^&]+).*")
-            .matcher(findAll(postRequestedFor(urlPathEqualTo("/token")))
-                .get(0)
-                .getBodyAsString());
+                .matcher(findAll(postRequestedFor(urlPathEqualTo("/token")))
+                        .get(0)
+                        .getBodyAsString());
         assertTrue(m.find());
         final String codeVerifier = m.group(1);
 
@@ -743,9 +738,8 @@ public class PluginTest {
         wireMockRule.stubFor(get(urlPathEqualTo("/jwks"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"keys\":[{"+encodePublicKey(keyPair)+
-                            ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""+
-                            "}]}")));
+                        .withBody("{\"keys\":[{" + encodePublicKey(keyPair) + ",\"use\":\"sig\",\"kid\":\"jwks_key_id\""
+                                + "}]}")));
         wireMockRule.stubFor(get(urlPathEqualTo("/authorization"))
                 .willReturn(aResponse()
                         .withStatus(302)
@@ -775,14 +769,13 @@ public class PluginTest {
                                         + EMAIL_FIELD + "\": \"" + TEST_USER_EMAIL_ADDRESS + "\",\n" + "   \""
                                         + GROUPS_FIELD + "\": \"" + TEST_USER_GROUPS[0] + "\"\n" + "  }"))));
 
-        jenkins.setSecurityRealm(
-                new TestRealm.Builder(wireMockRule)
+        jenkins.setSecurityRealm(new TestRealm.Builder(wireMockRule)
                 .WithUserInfoServerUrl("http://localhost:" + wireMockRule.port() + "/userinfo")
-                .WithJwksServerUrl("http://localhost:" + wireMockRule.port() + "/jwks")
-                .build());
+                        .WithJwksServerUrl("http://localhost:" + wireMockRule.port() + "/jwks")
+                        .build());
 
-        assertEquals("Shouldn't be authenticated",
-                getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
+        assertEquals(
+                "Shouldn't be authenticated", getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
 
         webClient.goTo(jenkins.getSecurityRealm().getLoginUrl());
 
@@ -798,9 +791,8 @@ public class PluginTest {
         wireMockRule.stubFor(get(urlPathEqualTo("/jwks"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"keys\":[{"+encodePublicKey(keyPair)+
-                            ",\"use\":\"sig\",\"kid\":\"wrong_key_id\""+
-                            "}]}")));
+                        .withBody("{\"keys\":[{" + encodePublicKey(keyPair)
+                                + ",\"use\":\"sig\",\"kid\":\"wrong_key_id\"" + "}]}")));
         wireMockRule.stubFor(get(urlPathEqualTo("/authorization"))
                 .willReturn(aResponse()
                         .withStatus(302)
@@ -831,18 +823,20 @@ public class PluginTest {
                                         + GROUPS_FIELD + "\": \"" + TEST_USER_GROUPS[0] + "\"\n" + "  }"))));
 
         TestRealm testRealm = new TestRealm.Builder(wireMockRule)
-            .WithUserInfoServerUrl("http://localhost:" + wireMockRule.port() + "/userinfo")
-            .WithJwksServerUrl("http://localhost:" + wireMockRule.port() + "/jwks")
-            .build();
+                .WithUserInfoServerUrl("http://localhost:" + wireMockRule.port() + "/userinfo")
+                        .WithJwksServerUrl("http://localhost:" + wireMockRule.port() + "/jwks")
+                        .build();
         jenkins.setSecurityRealm(testRealm);
 
-        assertEquals("Shouldn't be authenticated",
-                getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
+        assertEquals(
+                "Shouldn't be authenticated", getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
 
         webClient.goTo(jenkins.getSecurityRealm().getLoginUrl());
 
-        assertEquals("Should have refused authentication",
-                getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
+        assertEquals(
+                "Should have refused authentication",
+                getAuthentication().getPrincipal(),
+                Jenkins.ANONYMOUS.getPrincipal());
         testRealm.setDisableTokenVerification(true);
 
         webClient.goTo(jenkins.getSecurityRealm().getLoginUrl());
@@ -1388,10 +1382,9 @@ public class PluginTest {
     }
 
     private String createIdToken(PrivateKey privateKey, Map<String, Object> keyValues) throws Exception {
-        JsonWebSignature.Header header = new JsonWebSignature.Header()
-            .setAlgorithm("RS256")
-            .setKeyId("jwks_key_id");
-        long now = (long)(Clock.SYSTEM.currentTimeMillis()/1000);
+        JsonWebSignature.Header header =
+                new JsonWebSignature.Header().setAlgorithm("RS256").setKeyId("jwks_key_id");
+        long now = (long) (Clock.SYSTEM.currentTimeMillis() / 1000);
         IdToken.Payload payload = new IdToken.Payload()
                 .setExpirationTimeSeconds(now + 60L)
                 .setIssuedAtTimeSeconds(now)
@@ -1408,9 +1401,8 @@ public class PluginTest {
 
     private String createUserInfoJWT(PrivateKey privateKey, String userInfo) throws Exception {
 
-        JsonWebSignature.Header header = new JsonWebSignature.Header()
-            .setAlgorithm("RS256")
-            .setKeyId("jwks_key_id");
+        JsonWebSignature.Header header =
+                new JsonWebSignature.Header().setAlgorithm("RS256").setKeyId("jwks_key_id");
 
         JsonWebToken.Payload payload = new JsonWebToken.Payload();
         for (Map.Entry<String, JsonElement> keyValue :
@@ -1450,7 +1442,8 @@ public class PluginTest {
 
         jenkins.setSecurityRealm(new TestRealm(wireMockRule, null, null, null));
 
-        assertEquals("Shouldn't be authenticated", getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
+        assertEquals(
+                "Shouldn't be authenticated", getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
 
         webClient.assertFails(jenkins.getSecurityRealm().getLoginUrl(), 500);
     }
@@ -1484,19 +1477,19 @@ public class PluginTest {
 
         jenkins.setSecurityRealm(new TestRealm(wireMockRule, null, null, null));
 
-        assertEquals("Shouldn't be authenticated", getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
+        assertEquals(
+                "Shouldn't be authenticated", getAuthentication().getPrincipal(), Jenkins.ANONYMOUS.getPrincipal());
 
         webClient.assertFails(jenkins.getSecurityRealm().getLoginUrl(), 403);
     }
 
     /** Generate JWKS entry with public key of keyPair */
     String encodePublicKey(KeyPair keyPair) {
-        final RSAPublicKey rsaPKey = (RSAPublicKey)(keyPair.getPublic());
-        return "\"n\":\"" +
-            Base64.encodeBase64String(rsaPKey.getModulus().toByteArray()) +
-            "\",\"e\":\"" +
-            Base64.encodeBase64String(rsaPKey.getPublicExponent().toByteArray()) +
-            "\",\"alg\":\"RS256\",\"kty\":\"RSA\"";
+        final RSAPublicKey rsaPKey = (RSAPublicKey) (keyPair.getPublic());
+        return "\"n\":\"" + Base64.encodeBase64String(rsaPKey.getModulus().toByteArray())
+                + "\",\"e\":\""
+                + Base64.encodeBase64String(rsaPKey.getPublicExponent().toByteArray())
+                + "\",\"alg\":\"RS256\",\"kty\":\"RSA\"";
     }
 
     /**


### PR DESCRIPTION
Follow-up for 57eca2d7

It appears that the maven property override disabled the options initially used to format the project, so right now there's spaghetti formatting enabled.