### PR TITLE
`OicUserProperty` was discarded after saving the user config page

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicUserProperty.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.oic;
 
+import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
@@ -7,36 +8,42 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public class OicUserProperty extends UserProperty {
 
+    @Extension
     public static class Descriptor extends UserPropertyDescriptor {
 
         @Override
         public UserProperty newInstance(User user) {
-            LOGGER.fine("OicUserPropertyDescriptor.newInstance called, user:" + user);
-            return new OicUserProperty(user.getId(), new ArrayList<GrantedAuthority>());
+            return null;
         }
 
         @Override
-        public String getDisplayName() {
-            return Messages.OicUserProperty_OpenIdConnectUserProperty();
+        public boolean isEnabled() {
+            return false;
         }
     }
 
-    private static final Logger LOGGER = Logger.getLogger(OicUserProperty.class.getName());
-
     private final List<String> authorities = new ArrayList<>();
+    /** @deprecated not actually used (implicit in user to which it is attached) */
+    @Deprecated
     private final String userName;
 
-    public OicUserProperty(String userName, Collection<? extends GrantedAuthority> authorities) {
+    OicUserProperty(String userName, Collection<? extends GrantedAuthority> authorities) {
         this.userName = userName;
         for (GrantedAuthority authority : authorities) {
             this.authorities.add(authority.getAuthority());
         }
+    }
+
+    @Override
+    public UserProperty reconfigure(StaplerRequest req, JSONObject form) {
+        return this;
     }
 
     public List<String> getAuthorities() {
@@ -64,10 +71,5 @@ public class OicUserProperty extends UserProperty {
 
     public String getUserName() {
         return userName;
-    }
-
-    @Override
-    public UserPropertyDescriptor getDescriptor() {
-        return new Descriptor();
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/oic/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/oic/Messages.properties
@@ -1,7 +1,5 @@
 OicLogoutAction.OicLogout = Oic Logout
 
-OicUserProperty.OpenIdConnectUserProperty = OpenID Connect user property
-
 OicSecurityRealm.DisplayName = Login with Openid Connect
 OicSecurityRealm.ClientIdRequired = Client id is required.
 OicSecurityRealm.ClientSecretRequired = Client secret is required.

--- a/src/test/java/org/jenkinsci/plugins/oic/OicUserPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicUserPropertyTest.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class OicUserPropertyTest {
 
@@ -51,15 +50,5 @@ public class OicUserPropertyTest {
         userProp = new OicUserProperty(userName, authorities);
 
         assertThat(userProp.getAuthorities(), containsInAnyOrder(READ, ADMIN));
-    }
-
-    @Test
-    public void testGetDescriptor() {
-        String userName = "derek";
-        List<GrantedAuthority> authorities = Arrays.asList(GRANTED_AUTH1, GRANTED_AUTH2);
-
-        userProp = new OicUserProperty(userName, authorities);
-
-        assertNotNull(userProp.getDescriptor());
     }
 }


### PR DESCRIPTION
If you log in with OIDC with a groups field defined, then go to your user config page and create an API token, then use that API token to run the CLI command `who-am-i`, your groups are listed as expected. But if you then **Save** the same page and try the CLI command again, you are shown as having no groups. This is because saving the page wiped out the `OicUserProperty`. AFAICT this has been broken since #12. The corrected idiom can be seen in `LastGrantedAuthoritiesProperty` in core, a very similar property. Actually we could probably use that instead of `OicUserProperty` by merely calling `SecurityListener.fireLoggedIn`; I did not try that yet.