### PR TITLE
Bump Jenkins version to 2.426.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,12 @@
       <version>1.44.2</version>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,29 +56,27 @@
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
       <version>1.44.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-gson</artifactId>
-      <version>1.44.2</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-gson</artifactId>
+      <version>1.44.2</version>
     </dependency>
     <!-- see build plugin unpack -->
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
       <version>1.36.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.burt</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@
     <revision>4</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/oic-auth-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.effort>Max</spotbugs.effort>
-    <configuration-as-code.version>1569.vb_72405b_80249</configuration-as-code.version>
+    <configuration-as-code.version>1810.v9b_c30a_249a_4c</configuration-as-code.version>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
       <version>1.36.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.burt</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,24 @@
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-gson</artifactId>
       <version>1.44.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- see build plugin unpack -->
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
       <version>1.36.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.burt</groupId>
@@ -90,7 +102,6 @@
       <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>

--- a/src/test/java/org/jenkinsci/plugins/oic/EscapeHatchCrumbExclusionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/EscapeHatchCrumbExclusionTest.java
@@ -6,7 +6,6 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.server.Request;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -19,8 +18,8 @@ public class EscapeHatchCrumbExclusionTest {
 
     private FilterChain chain = null;
 
-    private Request newRequestWithPath(String requestPath) {
-        return new Request(null, null) {
+    private MockHttpServletRequest newRequestWithPath(String requestPath) {
+        return new MockHttpServletRequest() {
             @Override
             public String getPathInfo() {
                 return requestPath;
@@ -30,13 +29,13 @@ public class EscapeHatchCrumbExclusionTest {
 
     @Test
     public void process_WithNullPath() throws IOException, ServletException {
-        Request request = new Request(null, null);
+        MockHttpServletRequest request = newRequestWithPath("");
         assertFalse(crumb.process(request, response, chain));
     }
 
     @Test
     public void process_WithWrongPath() throws IOException, ServletException {
-        Request request = newRequestWithPath("fictionalPath");
+        MockHttpServletRequest request = newRequestWithPath("fictionalPath");
         assertFalse(crumb.process(request, response, chain));
     }
 
@@ -49,7 +48,7 @@ public class EscapeHatchCrumbExclusionTest {
             }
         };
 
-        Request request = newRequestWithPath("/securityRealm/escapeHatch");
+        MockHttpServletRequest request = newRequestWithPath("/securityRealm/escapeHatch");
         assertTrue(crumb.process(request, response, chain));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/MockHttpServletRequest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/MockHttpServletRequest.java
@@ -22,8 +22,7 @@ import javax.servlet.http.Part;
 
 public class MockHttpServletRequest implements HttpServletRequest {
 
-    public MockHttpServletRequest() {
-    }
+    public MockHttpServletRequest() {}
 
     @Override
     public String getAuthType() {

--- a/src/test/java/org/jenkinsci/plugins/oic/MockHttpServletRequest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/MockHttpServletRequest.java
@@ -1,0 +1,372 @@
+package org.jenkinsci.plugins.oic;
+
+import java.io.BufferedReader;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+
+public class MockHttpServletRequest implements HttpServletRequest {
+
+    public MockHttpServletRequest() {
+    }
+
+    @Override
+    public String getAuthType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMethod() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPathInfo() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPathTranslated() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContextPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getQueryString() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteUser() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestURI() {
+        return "/";
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServletPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String changeSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void login(String username, String password) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void logout() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Part> getParts() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Part getPart(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getContentLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getParameter(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getProtocol() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getScheme() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getServerPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSecure() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getRemotePort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLocalPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Based on version extract, it seems safe to bump Jenkins version to 2.426.3.
At the same time, update JCasc as indictated in #327

Also prepare for jetty 12 as requested in [JENKINS-73141](https://issues.jenkins.io/browse/JENKINS-73141)

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
