### PR TITLE
Stop persisting OicSession in HTTP session when only OIDC state is required

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSession.java
@@ -29,6 +29,7 @@ import com.google.api.client.auth.oauth2.AuthorizationCodeResponseUrl;
 import com.google.api.client.auth.openidconnect.IdToken;
 import com.google.api.client.util.Base64;
 import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Failure;
 import java.io.IOException;
@@ -43,6 +44,8 @@ import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+
+import static org.jenkinsci.plugins.oic.OicSecurityRealm.ensureStateAttribute;
 
 /**
  * The state of the OpenId connect request.
@@ -61,6 +64,7 @@ abstract class OicSession implements Serializable {
      * An opaque value used by the client to maintain state between the request and callback.
      */
     @VisibleForTesting
+    @NonNull
     String state = Base64.encodeBase64URLSafeString(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8))
             .substring(0, 20);
     /**
@@ -208,8 +212,7 @@ abstract class OicSession implements Serializable {
             // avoid session fixation
             session.invalidate();
         }
-        setupOicSession(request.getSession(true));
-
+        ensureStateAttribute(request.getSession(true), getState());
         return onSuccess(code, flow);
     }
 
@@ -222,6 +225,7 @@ abstract class OicSession implements Serializable {
         return from;
     }
 
+    @NonNull
     public String getState() {
         return this.state;
     }

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.servlet.http.HttpSession;
 import jenkins.model.Jenkins;
 import jenkins.security.LastGrantedAuthoritiesProperty;
 import org.junit.Before;
@@ -116,6 +117,12 @@ public class PluginTest {
                 .withQueryParam("scope", equalTo("openid email"))
                 .withQueryParam("nonce", matching(".+")));
         verify(postRequestedFor(urlPathEqualTo("/token")).withRequestBody(notMatching(".*&scope=.*")));
+        webClient.executeOnServer(() -> {
+            HttpSession session = Stapler.getCurrentRequest().getSession();
+            assertNull(OicSession.getCurrent());
+            assertNotNull(OicSecurityRealm.getStateAttribute(session));
+            return null;
+        });
     }
 
     private void browseLoginPage() throws IOException, SAXException {


### PR DESCRIPTION
In a CloudBees CI HA setup, I recently upgraded to 4.297.vcddb_d8a_e4694 (including #310). The various changes to `OicSecurityRealm` broke serialization due to usage of an anonymous inner class (extending `OicSession`) that gets stored in session.

Storing `OicSession` in session is actually only required for a brief amount of time, only between `doCommenceLogin` and `doFinishLogin`. Once the user is logged in, it is no longer necessary to store the whole object. The only thing that needs to be persisted is the state, as it gets used later for logging out.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
