### PR TITLE
Fix redirect loop when oic credentials have expired but jenkins session is still valid

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicCredentials.java
@@ -48,7 +48,7 @@ public class OicCredentials extends UserProperty implements Serializable {
 
         if (expiresInSeconds != null && expiresInSeconds > 0) {
             long allowedClockSkewFixed = Util.fixNull(allowedClockSkewSeconds, 60L);
-            this.expiresAtMillis = currentTimestamp + (expiresInSeconds - allowedClockSkewFixed) * 1000;
+            this.expiresAtMillis = (currentTimestamp + expiresInSeconds + allowedClockSkewFixed) * 1000;
         } else {
             this.expiresAtMillis = null;
         }

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1419,7 +1419,6 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
     private void redirectOrRejectRequest(HttpServletRequest req, HttpServletResponse res)
             throws IOException, ServletException {
         if (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization"))) {
-            // WebApp.get(Jenkins.get().servletContext).getSomeStapler().invoke(req, res, Jenkins.get(), getLoginUrl());
             req.getSession().invalidate();
             res.sendRedirect(Jenkins.get().getSecurityRealm().getLoginUrl());
         } else {

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -115,7 +115,6 @@ import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.WebApp;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -1420,7 +1419,9 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
     private void redirectOrRejectRequest(HttpServletRequest req, HttpServletResponse res)
             throws IOException, ServletException {
         if (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization"))) {
-            WebApp.get(Jenkins.get().servletContext).getSomeStapler().invoke(req, res, Jenkins.get(), getLoginUrl());
+            // WebApp.get(Jenkins.get().servletContext).getSomeStapler().invoke(req, res, Jenkins.get(), getLoginUrl());
+            req.getSession().invalidate();
+            res.sendRedirect(Jenkins.get().getSecurityRealm().getLoginUrl());
         } else {
             res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expired");
         }

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -450,12 +450,13 @@ public class PluginTest {
             User user = User.get2(authentication);
             OicCredentials credentials = user.getProperty(OicCredentials.class);
 
+            //setting currentTimestamp == 1 guarantees this will be an expired cred
             user.addProperty(new OicCredentials(
                     credentials.getAccessToken(),
                     credentials.getIdToken(),
                     credentials.getRefreshToken(),
                     60L,
-                    Clock.SYSTEM.currentTimeMillis() - 3600,
+                    1L,
                     60L));
 
             return null;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

to reproduce:

1. configure a jenkins instance to auth using the plugin, do not enable refresh tokens
2. assume your oic crentials lifetime is 120s (at least that is the case for my test provider)
3. assume default skew allowance of 60s
4. login to your jenkins instance
5. notice that after only 60s, your OIC credentials have now expired!
6. any subsequent attempt to access the instance results in a redirect loop between the provider and jenkins


Although the proposed PR fixes the issue AFAICT, I am not 100% confident it is the correct fix.  This issue first appears in release [4.297.vcddb_d8a_e4694](https://github.com/jenkinsci/oic-auth-plugin/releases/tag/4.297.vcddb_d8a_e4694), but i have not been able to identify exactly what i believe changed to cause this behavior.  My theory is that because the jenkins web session is still valid, it allows the request, which is then flagged as invalid because the OIC credentials have expired, kicking the whole loop off again.  Hopefully you can confirm or deny this @krezovic 


I also believe that the clock skew was mistakenly being subtracted from the credentials  "expires in X seconds" calculation - my understanding was the clock skew should add an additional "buffer" to the lifetime of the credentials in order to accommodate slight variances in different clocks.

### Testing done
Lots of manual testing....
I've also fixed 2 tests that i believe cover the changes made in this PR:

-  `testRefreshTokenAndTokenExpiration_withoutRefreshToken()`
The test was originally using `JenkinsRule.WebClient` to check for a `302` respoonse when the `OicCredentials` are expired.  Normally `WebClient` would follow redirects, and the test was only passing with the expected `Blocked - 302`  due to the redirect loop that was occurring.  Fixing that caused this test to fail, so i've replaced that bit of test code with a java `HttpClient` set to not follow redirects.

- the [expire helper method](https://github.com/jenkinsci/oic-auth-plugin/pull/357/files#diff-fbf2979fa131a62f8efe7b73f007ba2048436733e151acf28b80836a70a7e901R469) was using the wrong number of `ms` to force the credentials to be expired.  This apparently worked previously because the clock skew was actually being subtracted from the credential lifetime (instead of augmenting it).  Since all we care about is ensuring the credentials appear expired I simply set the creation instant to `1` (ie. the first millisecond of time ever).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
