### PR TITLE
Fix calculation of expiration timestamp

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicCredentials.java
@@ -48,7 +48,7 @@ public class OicCredentials extends UserProperty implements Serializable {
 
         if (expiresInSeconds != null && expiresInSeconds > 0) {
             long allowedClockSkewFixed = Util.fixNull(allowedClockSkewSeconds, 60L);
-            this.expiresAtMillis = (currentTimestamp + expiresInSeconds + allowedClockSkewFixed) * 1000;
+            this.expiresAtMillis = currentTimestamp + (expiresInSeconds + allowedClockSkewFixed) * 1000;
         } else {
             this.expiresAtMillis = null;
         }


### PR DESCRIPTION
`currentTimestamp` is in millis already which is why it should not be mulitplied by 1000.

The constructor of `OicCredentials` is called with `CLOCK.millis()` ([here](https://github.com/jenkinsci/oic-auth-plugin/blob/master/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java#L1000) and [here](https://github.com/jenkinsci/oic-auth-plugin/blob/master/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java#L1490)) for the `currentTimestamp` parameter which shows that `currentTimestamp` is indeed in millis and not seconds.

This bug was introduced in bba32e09 (PR #357).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
