### PR TITLE
Compare username based on ID strategy on token refresh

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1516,7 +1516,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
 
         String username = determineStringField(userNameFieldExpr, parsedIdToken, userInfo);
 
-        if (!expectedUsername.equals(username)) {
+        if (!User.idStrategy().equals(expectedUsername, username)) {
             httpResponse.sendError(
                     HttpServletResponse.SC_UNAUTHORIZED, "User name was not the same after refresh request");
             return false;


### PR DESCRIPTION
When using the option to refresh the token, the expected username and the username from the token might differ in their case.

This lead to an "Username was not the same after refresh". To take the User ID strategy into account, one can use `User.idStrategy().equals` instead  of a plain `equals` comparison.

Fixes: https://github.com/jenkinsci/oic-auth-plugin/issues/392

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
