### PR TITLE
Redirect to login page in case token is expired instead of showing an error page

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1438,7 +1438,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
             if (isUseRefreshTokens() && !Strings.isNullOrEmpty(credentials.getRefreshToken())) {
                 return refreshExpiredToken(user.getId(), credentials, httpRequest, httpResponse);
             } else if (!isTokenExpirationCheckDisabled()) {
-                redirectOrRejectRequest(httpRequest, httpResponse);
+                redirectToLoginUrl(httpRequest, httpResponse);
                 return false;
             }
         }
@@ -1446,7 +1446,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         return true;
     }
 
-    private void redirectOrRejectRequest(HttpServletRequest req, HttpServletResponse res)
+    private void redirectToLoginUrl(HttpServletRequest req, HttpServletResponse res)
             throws IOException, ServletException {
         if (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization"))) {
             req.getSession().invalidate();
@@ -1564,7 +1564,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
             // RT expired or session terminated
             if (!isTokenExpirationCheckDisabled()) {
                 try {
-                    redirectOrRejectRequest(httpRequest, httpResponse);
+                    redirectToLoginUrl(httpRequest, httpResponse);
                 } catch (ServletException ex) {
                     httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expired");
                 }

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1555,7 +1555,8 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         return true;
     }
 
-    private void handleTokenRefreshException(TokenResponseException e, HttpServletRequest httpRequest, HttpServletResponse httpResponse)
+    private void handleTokenRefreshException(
+            TokenResponseException e, HttpServletRequest httpRequest, HttpServletResponse httpResponse)
             throws IOException {
         TokenErrorResponse details = e.getDetails();
 
@@ -1563,9 +1564,9 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
             // RT expired or session terminated
             if (!isTokenExpirationCheckDisabled()) {
                 try {
-                  redirectOrRejectRequest(httpRequest, httpResponse);
+                    redirectOrRejectRequest(httpRequest, httpResponse);
                 } catch (ServletException ex) {
-                  httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expired");
+                    httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expired");
                 }
             }
         } else {

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -85,7 +85,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * goes through a login scenario, the openid provider is mocked and always returns state. We aren't checking
- * if if openid connect or if the openid connect implementation works. Rather we are only
+ * if openid connect or if the openid connect implementation works. Rather we are only
  * checking if the jenkins interaction works and if the plugin code works.
  */
 @Url("https://jenkins.io/blog/2018/01/13/jep-200/")
@@ -480,7 +480,7 @@ public class PluginTest {
                         .withHeader("Content-Type", "application/json")
                         .withBody("{ \"error\": \"invalid_grant\" }")));
         expire();
-        webClient.assertFails(jenkins.getSearchUrl(), 401);
+        webClient.assertFails(jenkins.getSearchUrl(), 500);
 
         verify(postRequestedFor(urlPathEqualTo("/token")).withRequestBody(containing("grant_type=refresh_token")));
     }
@@ -1018,7 +1018,7 @@ public class PluginTest {
         // the default behavior expects there to be a valid oic session, so token based
         // access should now fail (unauthorized)
         rsp = getPageWithGet(TEST_USER_USERNAME, token, "/whoAmI/api/xml");
-        MatcherAssert.assertThat("response should have been 401\n" + rsp.body(), rsp.statusCode(), is(401));
+        MatcherAssert.assertThat("response should have been 302\n" + rsp.body(), rsp.statusCode(), is(302));
 
         // enable "traditional api token access"
         testRealm.setAllowTokenAccessWithoutOicSession(true);


### PR DESCRIPTION
Instead of showing an error page, the user should be redirected to the login page.

Proposal to solve: https://github.com/jenkinsci/oic-auth-plugin/issues/396

### Testing done

I have tested this with [4.340.ve70636c6590e](https://github.com/jenkinsci/oic-auth-plugin/releases/tag/4.340.ve70636c6590e) and by setting the following

(Cognito) Refresh Configuration:

Refresh token expiration: 60 minutes
Access token expiration: 10 minutes
ID token expiration: 10 minutes

After 60 minutes, I got redirected to the login page instead of getting presented an error page.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
