### PR TITLE
Use endSessionUrl instead of endSessionEndpoint for manual configuration in UI

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/oic/OicServerManualConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/oic/OicServerManualConfiguration/config.jelly
@@ -21,7 +21,7 @@
     <f:entry title="${%JwksServerUrl}" field="jwksServerUrl">
         <f:textbox />
     </f:entry>
-    <f:entry title="${%EndSessionUrl}" field="endSessionEndpoint">
+    <f:entry title="${%EndSessionUrl}" field="endSessionUrl">
         <f:textbox />
     </f:entry>
     <f:entry title="${%Scopes}" field="scopes">


### PR DESCRIPTION
https://github.com/jenkinsci/oic-auth-plugin/pull/399 introduced a breaking change regarding the plugin configuration.

Formerly, the UI displayed the deprecated `endSessionEndpoint`, which has been renamed to `endSessionUrl` as part of the `OicServerManualConfiguration`, which is now displayed in the manual configuration.

### Testing done

* Check out the latest tag
* Start Jenkins with manually configured OIC Server incl. configured `endSessionUrl`
* Check UI and see field `End session URL for OpenID Provider` empty
* Apply fix to plugin & restart Jenkins with patched plugin
* Field `End session URL for OpenID Provider` now contains configured `endSessionUrl`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
