### PR TITLE
Resuse the original user principal to avoid crumb issues.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1274,6 +1274,12 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
                         HttpServletResponse.SC_UNAUTHORIZED, "User name was not the same after refresh request");
                 return false;
             }
+            // the username may have changed case during a call, but still be the same user (as we have checked the
+            // idStrategy)
+            // we need to keep using exactly the same principal otherwise there is a potential for crumbs not to match.
+            // whilst we could do some normalization of the username, just use the original (expected) username
+            // see https://github.com/jenkinsci/oic-auth-plugin/issues/411
+            username = expectedUsername;
 
             if (failedCheckOfTokenField(idToken)) {
                 throw new FailedCheckOfTokenException(client.getConfiguration().findLogoutUrl());

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1279,6 +1279,15 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
             // we need to keep using exactly the same principal otherwise there is a potential for crumbs not to match.
             // whilst we could do some normalization of the username, just use the original (expected) username
             // see https://github.com/jenkinsci/oic-auth-plugin/issues/411
+            if (LOGGER.isLoggable(Level.FINE)) {
+                Authentication a = SecurityContextHolder.getContext().getAuthentication();
+                User u = User.get2(a);
+                LOGGER.log(
+                        Level.FINE,
+                        "Token refresh.  Current Authentitcation principal: " + a.getName() + " user id:"
+                                + (u == null ? "null user" : u.getId()) + " newly retreived username would have been: "
+                                + username);
+            }
             username = expectedUsername;
 
             if (failedCheckOfTokenField(idToken)) {


### PR DESCRIPTION
as it has been observed that the case of a user may change during a refreesh flow even though they are the same user, the crumb uses the Authentications name (principal), which would be different as we use the returned value.
Rather than using the new value, after checking it is the same id (according to the ID Strategy) we use the original so that the crumb can be matched.

maybe fixes: #411

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
