### PR TITLE
Redirect to login page if refresh token has expired

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1376,10 +1376,12 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
     }
 
     private void redirectToLoginUrl(HttpServletRequest req, HttpServletResponse res) throws IOException {
-        if (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization"))) {
+        if (req != null && (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization")))) {
             req.getSession().invalidate();
         }
-        res.sendRedirect(Jenkins.get().getSecurityRealm().getLoginUrl());
+        if (res != null) {
+            res.sendRedirect(Jenkins.get().getSecurityRealm().getLoginUrl());
+        }
     }
 
     public boolean isExpired(OicCredentials credentials) {
@@ -1475,7 +1477,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
                     return false;
                 }
                 LOGGER.log(Level.FINE, "Failed to refresh expired token", e);
-                redirectToLoginUrl(Stapler.getCurrentRequest(), Stapler.getCurrentResponse());
+                redirectToLoginUrl(httpRequest, httpResponse);
                 return false;
             }
             LOGGER.log(Level.WARNING, "Failed to refresh expired token", e);


### PR DESCRIPTION
The user should be redirected when the refresh token has expired.

Fixes https://github.com/jenkinsci/oic-auth-plugin/issues/457

### Changes

* Check if variable is set to avoid NullPointerException
* Use request/response variables instead of Stapler requests

### Testing done

* This change has been successfully tested with a AWS Cognito connection.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
