### PR TITLE
Slim down JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,11 @@
           <artifactId>jackson-datatype-jsr310</artifactId>
         </exclusion>
         <exclusion>
+          <!-- not needed at runtime -->
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>findbugs-annotations</artifactId>
+        </exclusion>
+        <exclusion>
           <!-- consume from commons-lang3-api plugin -->
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
@@ -156,6 +161,11 @@
           <artifactId>jackson-databind</artifactId>
         </exclusion>
         <exclusion>
+          <!-- not needed at runtime -->
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>findbugs-annotations</artifactId>
+        </exclusion>
+        <exclusion>
           <!-- consume from Jenkins core -->
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
@@ -169,6 +179,11 @@
           <!-- consume from Jenkins core -->
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- consume from Jenkins core -->
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
#455 inadvertently packaged two new JARs into the JPI: `spring-core-6.1.14.jar` and `findbugs-annotations-3.0.1.jar`. FindBugs is a static analysis tool without runtime impact, and the Spring Core JAR isn't used at runtime from the plugin, anyway: it is provided by Jenkins core, which takes precedence (see [here](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/) for details). Nor is shipping `spring-core-6.1.14.jar` a problem today, as it is not vulnerable to any CVEs that might trip up scanners. But in the long term, it is a liability to ship a Spring library that we do not use that might trip scanners, so slim down the JPI so that it ships the same set of JARs (but with upgraded versions) as we shipped prior to #455.

### Testing done

- CI build
- Verified that the JPI contained no new JARs (just upgraded JARs) relative to #455

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
