### PR TITLE
Fix FormValidation check when overwriting scopes when using the OicServerWellKnownConfiguration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicServerWellKnownConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicServerWellKnownConfiguration.java
@@ -219,12 +219,12 @@ public class OicServerWellKnownConfiguration extends OicServerConfiguration {
         }
 
         @POST
-        public FormValidation doCheckOverrideScopes(@QueryParameter String overrideScopes) {
+        public FormValidation doCheckScopesOverride(@QueryParameter String scopesOverride) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            if (Util.fixEmptyAndTrim(overrideScopes) == null) {
+            if (Util.fixEmptyAndTrim(scopesOverride) == null) {
                 return FormValidation.ok();
             }
-            if (!overrideScopes.toLowerCase().contains("openid")) {
+            if (!scopesOverride.toLowerCase().contains("openid")) {
                 return FormValidation.warning(Messages.OicSecurityRealm_RUSureOpenIdNotInScope());
             }
             return FormValidation.ok();

--- a/src/test/java/org/jenkinsci/plugins/oic/OicServerWellKnownConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicServerWellKnownConfigurationTest.java
@@ -83,13 +83,13 @@ public class OicServerWellKnownConfigurationTest {
     public void doCheckOverrideScopes() throws IOException {
         DescriptorImpl descriptor = getDescriptor();
 
-        assertThat(descriptor.doCheckOverrideScopes(null), hasKind(FormValidation.Kind.OK));
-        assertThat(descriptor.doCheckOverrideScopes(""), hasKind(FormValidation.Kind.OK));
+        assertThat(descriptor.doCheckScopesOverride(null), hasKind(FormValidation.Kind.OK));
+        assertThat(descriptor.doCheckScopesOverride(""), hasKind(FormValidation.Kind.OK));
         assertThat(
-                descriptor.doCheckOverrideScopes("openid email profile address phone offline_access"),
+                descriptor.doCheckScopesOverride("openid email profile address phone offline_access"),
                 hasKind(FormValidation.Kind.OK));
         assertThat(
-                descriptor.doCheckOverrideScopes("blah"),
+                descriptor.doCheckScopesOverride("blah"),
                 allOf(
                         hasKind(FormValidation.Kind.WARNING),
                         withMessage("Are you sure you don't want to include 'openid' as a scope?")));


### PR DESCRIPTION
The field name in `config.jelly` for `OicServerWellKnownConfiguration` is `scopesOverride` not `overrideScopes`. 
This PR aligns the Java method.

### Testing done

This change has been tested by unit tests as well as manual local testing with `mvn clean hpi:run`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
