### PR TITLE
Update contributing guide to include Maven version requirement

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,8 @@ This document provides information about contributing code to
 Jenkins' OpenID Connect Authentication plug-in.
 
 Before developing this plugin, please ensure that your development environment meets the following requirements:
-  - **Maven 3.9.6 or later versions is required.**
+  - Maven 3.9.6 or later
+  - Java 17 or later
 
 There are many ways to contribute which are more or less the same as
 the [general Jenkins participation](https://www.jenkins.io/participate/)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 This document provides information about contributing code to
 Jenkins' OpenID Connect Authentication plug-in.
 
+Before developing this plugin, please ensure that your development environment meets the following requirements:
+  - **Maven 3.9.6 or later versions is required.**
+
 There are many ways to contribute which are more or less the same as
 the [general Jenkins participation](https://www.jenkins.io/participate/)
 needs. This contribution guide comes in complement to the general guidelines


### PR DESCRIPTION
### What I did
- Added Maven 3.9.6 requirement to the contributing guide.

### Testing done
- Verified the documentation build process to ensure no formatting issues.
- Manually reviewed the contributing guide for clarity and completeness.

### Submitter checklist
- [x] The pull request is from a feature branch and not the main branch.
- [x] The pull request title represents the desired changelog entry.
- [x] The documentation update is clearly described.
- [x] Linked to the relevant issue in GitHub.