### PR TITLE
Add support for avatars

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicAvatarProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicAvatarProperty.java
@@ -5,10 +5,8 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
-import java.util.logging.Logger;
 
 public class OicAvatarProperty extends UserProperty {
-    private static final Logger LOGGER = Logger.getLogger(OicAvatarProperty.class.getName());
 
     private final AvatarImage avatarImage;
 
@@ -32,7 +30,7 @@ public class OicAvatarProperty extends UserProperty {
     }
 
     public String getDisplayName() {
-        return "Openid Connect Avatar";
+        return "OpenID Connect Avatar";
     }
 
     public String getIconFileName() {
@@ -49,7 +47,7 @@ public class OicAvatarProperty extends UserProperty {
         @Override
         @NonNull
         public String getDisplayName() {
-            return "Openid Connect Avatar";
+            return "OpenID Connect Avatar";
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/oic/OicAvatarProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicAvatarProperty.java
@@ -1,0 +1,80 @@
+package org.jenkinsci.plugins.oic;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import java.util.logging.Logger;
+
+public class OicAvatarProperty extends UserProperty {
+    private static final Logger LOGGER = Logger.getLogger(OicAvatarProperty.class.getName());
+
+    private final AvatarImage avatarImage;
+
+    public OicAvatarProperty(AvatarImage avatarImage) {
+        this.avatarImage = avatarImage;
+    }
+
+    public String getAvatarUrl() {
+        if (isHasAvatar()) {
+            return getAvatarImageUrl();
+        }
+        return null;
+    }
+
+    private String getAvatarImageUrl() {
+        return avatarImage.url;
+    }
+
+    public boolean isHasAvatar() {
+        return avatarImage != null && avatarImage.isValid();
+    }
+
+    public String getDisplayName() {
+        return "Openid Connect Avatar";
+    }
+
+    public String getIconFileName() {
+        return null;
+    }
+
+    public String getUrlName() {
+        return "oic-avatar";
+    }
+
+    @Extension
+    public static class DescriptorImpl extends UserPropertyDescriptor {
+
+        @Override
+        @NonNull
+        public String getDisplayName() {
+            return "Openid Connect Avatar";
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
+        @Override
+        public UserProperty newInstance(User user) {
+            return new OicAvatarProperty(null);
+        }
+    }
+
+    /**
+     * OIC avatar is standard picture field on the profile claim.
+     */
+    public static class AvatarImage {
+        private final String url;
+
+        public AvatarImage(String url) {
+            this.url = url;
+        }
+
+        public boolean isValid() {
+            return url != null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/oic/OicAvatarResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicAvatarResolver.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.oic;
+
+import hudson.Extension;
+import hudson.model.User;
+import hudson.tasks.UserAvatarResolver;
+
+@Extension
+public class OicAvatarResolver extends UserAvatarResolver {
+    @Override
+    public String findAvatarFor(User user, int width, int height) {
+        if (user != null) {
+            OicAvatarProperty avatarProperty = user.getProperty(OicAvatarProperty.class);
+            if (avatarProperty != null) {
+                return avatarProperty.getAvatarUrl();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1079,11 +1079,11 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         String avatarUrl = determineStringField(avatarFieldExpr, idToken, userInfo);
         OicAvatarProperty oicAvatarProperty;
         if (avatarUrl != null) {
-            LOGGER.finest("Avatar url is: " + avatarUrl);
+            LOGGER.finest(() -> "Avatar url is: " + avatarUrl);
             OicAvatarProperty.AvatarImage avatarImage = new OicAvatarProperty.AvatarImage(avatarUrl);
             oicAvatarProperty = new OicAvatarProperty(avatarImage);
         } else {
-            LOGGER.finest("No avatar URL found for user %s. Ensure to remove existing avatar".formatted(user.getId()));
+            LOGGER.finest(() -> "No avatar URL found for user " + user.getId() + ". Ensure to remove existing avatar");
             oicAvatarProperty = new OicAvatarProperty(null);
         }
         user.addProperty(oicAvatarProperty);

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1076,20 +1076,17 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         }
 
         // Set avatar if possible
-        try {
-            String avatarUrl = determineStringField(avatarFieldExpr, idToken, userInfo);
-            if (avatarUrl != null) {
-                LOGGER.finest("Avatar url is: " + avatarUrl);
-                OicAvatarProperty.AvatarImage avatarImage = new OicAvatarProperty.AvatarImage(avatarUrl);
-                OicAvatarProperty oicAvatarProperty = new OicAvatarProperty(avatarImage);
-                user.addProperty(oicAvatarProperty);
-            } else {
-                LOGGER.finest("No avatar URL found");
-            }
-
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to save profile photo for %s".formatted(user.getId()), e);
+        String avatarUrl = determineStringField(avatarFieldExpr, idToken, userInfo);
+        OicAvatarProperty oicAvatarProperty;
+        if (avatarUrl != null) {
+            LOGGER.finest("Avatar url is: " + avatarUrl);
+            OicAvatarProperty.AvatarImage avatarImage = new OicAvatarProperty.AvatarImage(avatarUrl);
+            oicAvatarProperty = new OicAvatarProperty(avatarImage);
+        } else {
+            LOGGER.finest("No avatar URL found for user %s. Ensure to remove existing avatar".formatted(user.getId()));
+            oicAvatarProperty = new OicAvatarProperty(null);
         }
+        user.addProperty(oicAvatarProperty);
 
         user.addProperty(credentials);
 

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -104,6 +104,8 @@ class PluginTest {
     private static final String[] TEST_USER_GROUPS_REFRESHED = new String[] {"group1", "group2", "group3"};
     private static final List<Map<String, String>> TEST_USER_GROUPS_MAP =
             List.of(Map.of("id", "id1", "name", "group1"), Map.of("id", "id2", "name", "group2"));
+    private static final String TEST_ENCODED_AVATAR =
+            "iVBORw0KGgoAAAANSUhEUgAAABsAAAAaCAYAAABGiCfwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAH8SURBVEhL7ZbPK0RRFMe/z/w05Mc0Mo0mZeFXGM1IFDFEfjWKks1sSIkipDSrt1M2FpY2FpSllK2yV/4DWYlSLGzw7rvufe/Rm5n3a4rJwmdz77nz3vnee865Z56QSCQoikSJNhaFvy823Ulwsf6BWFTWVpxRsFionGJ7TEZtBSCmCEoE5ykvWGxtmMDvUefRIDDf/UtibXUUEx3ZzpcHCSpKNcOGgsQyk0QZbx/ecHDxhOdXCQEvsJpU1+1wLDYVk9FYq54qc/yAtcN7HF0+K/ZMnKChxj6cjsT8Hop1lqsvPojq+F1SR0EQsDMuKXMrHIkt9smoLtMME+L1wFCL9VWwFQtXUqR7nd2nzRECt0szDLAV2xq1dqAnXAmke8yLxVIsXk+RbLZPvJ7Ffh5y43dMxVjOHSU9F37h9cWkx1RsNi6zctaMHLxuthPdmMtUjLJrkp9nVyQSEbX5NwEvxf68BJ/H2Flr1I9wtRtLI0GU+oz32xQGzm6yfzN8ciUpsxZkLMTxs01UlbmUUJvBW9t4e/bp8sSiQYq5LutSF08flQ5ycvWirRjDc8cbwhd5YdydIUo3t6KpzgeJdZGNVMg0jJyAD5CZ1vWd+kzWNwg/+tFC4RVoxTtzN7DnYS0uR4z/VYgpCeVsRz/FPYu0eO5W5v9fVz9CEcWAT+xkgmHqzLIIAAAAAElFTkSuQmCC";
 
     @RegisterExtension
     static WireMockExtension wireMock = WireMockExtension.newInstance()
@@ -332,6 +334,28 @@ class PluginTest {
             var groupName = group.get("name");
             assertTrue(user.getAuthorities().contains(groupName), "User should be part of group " + groupName);
         }
+    }
+
+    @Test
+    void testLoginUsingUserInfoEndpointWithAvatar() throws Exception {
+        mockAuthorizationRedirectsToFinishLogin();
+        mockTokenReturnsIdTokenWithoutValues();
+        mockUserInfoWithAvatar(wireMock);
+        configureWellKnown(null, null);
+
+        // Return avatar image when requested
+        wireMock.stubFor(get(urlPathEqualTo("/my-avatar.png"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "image/png")
+                        .withBody(Base64.getDecoder().decode(TEST_ENCODED_AVATAR))));
+
+        jenkins.setSecurityRealm(new TestRealm(wireMock, null, EMAIL_FIELD, GROUPS_FIELD, true));
+        assertAnonymous();
+        browseLoginPage();
+        var user = assertTestUser();
+        assertTestUserEmail(user);
+        assertTestAvatar(user, wireMock);
     }
 
     @Test
@@ -822,6 +846,14 @@ class PluginTest {
                 "Email should be " + TEST_USER_EMAIL_ADDRESS);
     }
 
+    private static void assertTestAvatar(User user, WireMockExtension wireMock) {
+        String expectedAvatarUrl = "http://localhost:%d/my-avatar.png".formatted(wireMock.getPort());
+        OicAvatarProperty avatarProperty = user.getProperty(OicAvatarProperty.class);
+        assertEquals(expectedAvatarUrl, avatarProperty.getAvatarUrl(), "Avatar url should be " + expectedAvatarUrl);
+        assertEquals("Openid Connect Avatar", avatarProperty.getDisplayName());
+        assertNull(avatarProperty.getIconFileName(), "Icon filename must be null");
+    }
+
     private @NonNull User assertTestUser() {
         Authentication authentication = getAuthentication();
         assertEquals(TEST_USER_USERNAME, authentication.getPrincipal(), "Should be logged-in as " + TEST_USER_USERNAME);
@@ -1234,14 +1266,18 @@ class PluginTest {
     }
 
     private void mockUserInfoWithGroups(@Nullable Object groups) {
-        mockUserInfo(getUserInfo(groups));
+        mockUserInfo(getUserInfo(groups, null));
+    }
+
+    private void mockUserInfoWithAvatar(WireMockExtension wireMock) {
+        mockUserInfo(getUserInfo(null, wireMock));
     }
 
     private void mockUserInfoJwtWithTestGroups(KeyPair keyPair, Object testUserGroups) throws Exception {
         wireMock.stubFor(get(urlPathEqualTo("/userinfo"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/jwt")
-                        .withBody(createUserInfoJWT(keyPair.getPrivate(), toJson(getUserInfo(testUserGroups))))));
+                        .withBody(createUserInfoJWT(keyPair.getPrivate(), toJson(getUserInfo(testUserGroups, null))))));
     }
 
     private void mockUserInfo(Map<String, Object> userInfo) {
@@ -1251,13 +1287,16 @@ class PluginTest {
                         .withBody(toJson(userInfo))));
     }
 
-    private static Map<String, Object> getUserInfo(@Nullable Object groups) {
+    private static Map<String, Object> getUserInfo(@Nullable Object groups, WireMockExtension wireMock) {
         Map<String, Object> userInfo = new HashMap<>();
         userInfo.put("sub", TEST_USER_USERNAME);
         userInfo.put(FULL_NAME_FIELD, TEST_USER_FULL_NAME);
         userInfo.put(EMAIL_FIELD, TEST_USER_EMAIL_ADDRESS);
         if (groups != null) {
             userInfo.put(GROUPS_FIELD, groups);
+        }
+        if (wireMock != null) {
+            userInfo.put("picture", "http://localhost:" + wireMock.getPort() + "/my-avatar.png");
         }
         return userInfo;
     }


### PR DESCRIPTION
Fix for https://github.com/jenkinsci/oic-auth-plugin/issues/512 (more details here)

- Avatar is an URL given when profile scope is requested (standard OpenID)
- Added tests

Other known plugin that support avatar extension point

https://github.com/jenkinsci/avatar-plugin
https://github.com/jenkinsci/azure-ad-plugin
https://github.com/jenkinsci/gravatar-plugin

### Testing done

There was some fixes on Jenkins 2.495 for avatar rendering. That's why it would look different

On 2.479.1 (this current plugin jenkins.version). This is was fixed by https://github.com/jenkinsci/jenkins/pull/10180 which should be included on ~3 month LTS

![avatar1](https://github.com/user-attachments/assets/377a9743-5a08-41f5-b06c-3c763993d6ce)

On 2.495 this looks much better

![avatar2](https://github.com/user-attachments/assets/ac219dea-faa7-43e4-9b84-f32bf9ff9cb9)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
