### PR TITLE
Fix: Make Authorization header 'Basic' check case-insensitive (RFC 7235)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1411,7 +1411,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         if (isAllowTokenAccessWithoutOicSession()) {
             // check if this is a valid api token based request
             String authHeader = httpRequest.getHeader("Authorization");
-            if (authHeader != null && authHeader.startsWith("Basic ")) {
+            if (authHeader != null && authHeader.regionMatches(true, 0, "Basic ", 0, 6)) {
                 String token = new String(Base64.getDecoder().decode(authHeader.substring(6)), StandardCharsets.UTF_8)
                         .split(":")[1];
 


### PR DESCRIPTION
- Make the Authorization header check for 'Basic' case-insensitive as per RFC 7235.
- Add a test to ensure lowercase 'basic' in the Authorization header works for API token authentication.

Closes #560.