### PR TITLE
There is no need to encode login parameters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -618,7 +618,7 @@ public class OicSecurityRealm extends SecurityRealm implements Serializable {
         opMetadataResolver.init();
         if (loginQueryParameters != null && !loginQueryParameters.isEmpty()) {
             for (LoginQueryParameter lqp : loginQueryParameters) {
-                conf.addCustomParam(lqp.getURLEncodedKey(), lqp.getURLEncodedValue());
+                conf.addCustomParam(lqp.getKey(), lqp.getValue());
             }
         }
         return conf;

--- a/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTest.java
@@ -2,13 +2,16 @@ package org.jenkinsci.plugins.oic;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import hudson.util.Secret;
+import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
+import org.htmlunit.Page;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -20,6 +23,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -247,5 +254,39 @@ class OicSecurityRealmTest {
                         .sorted()
                         .toList(),
                 Stream.of(queryParams.split("&")).sorted().toList());
+    }
+
+    @Test
+    public void testOpenIdLoginEndpointWithCustomLoginQueryParameters(JenkinsRule jenkinsRule) throws Exception {
+        jenkinsRule
+                .jenkins
+                .getDescriptorList(LogoutQueryParameter.class)
+                .add(new LogoutQueryParameter.DescriptorImpl());
+        TestRealm realm = new TestRealm.Builder(wireMock)
+                .WithMinimalDefaults()
+                        .WithLoginQueryParameters(List.of(
+                                new LoginQueryParameter("key1", "value1"),
+                                new LoginQueryParameter("key with space", " space "),
+                                new LoginQueryParameter("blah:wibble", "anything:here"),
+                                new LoginQueryParameter("emailaddr", "joe@example.com")))
+                        .build();
+        jenkinsRule.jenkins.setSecurityRealm(realm);
+        try (WebClient wc = jenkinsRule.createWebClient()) {
+            wc.getOptions().setRedirectEnabled(false);
+            wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            Page redirect = wc.goTo("securityRealm/commenceLogin", null);
+            String locationHeader = redirect.getWebResponse().getResponseHeaderValue("Location");
+            // alas PAC4j does not maintain any ordering of its built URL
+            assertThat(locationHeader, startsWith(wireMock.baseUrl()));
+            URL u = new URL(locationHeader);
+            String[] queries = u.getQuery().split("&");
+            assertThat(
+                    queries,
+                    allOf(
+                            hasItemInArray("key1=value1"),
+                            hasItemInArray("key%20with%20space=space"),
+                            hasItemInArray("blah%3Awibble=anything%3Ahere"),
+                            hasItemInArray("emailaddr=joe%40example.com")));
+        }
     }
 }


### PR DESCRIPTION
The framework encodes the login parameters for us, so there is no need to do it.

fixes: #573

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
