### PR TITLE
Remove `overrideScopes` from `GOOGLE.md`

### DIFF
--- a/docs/configuration/GOOGLE.md
+++ b/docs/configuration/GOOGLE.md
@@ -52,7 +52,6 @@ jenkins:
       automanualconfigure: auto
       clientId: identifier-client-id
       clientSecret: identifuer-client-secret
-      overrideScopes: openid profile name email
       userNameField: sub
       fullNameFieldName: name
       emailFieldName: email


### PR DESCRIPTION
I found that the Google IdP complained that the `name` scope was invalid. After deleting this override, login worked.