### PR TITLE
Fix OIDC refresh fallback storms

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.oic;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.Striped;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.GrantType;
@@ -80,6 +81,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -150,6 +152,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OicSecurityRealm extends SecurityRealm {
 
     private static final Logger LOGGER = Logger.getLogger(OicSecurityRealm.class.getName());
+    private static final Striped<Lock> USER_REFRESH_LOCKS = Striped.lazyWeakLock(64);
     private IdStrategy userIdStrategy;
     private IdStrategy groupIdStrategy;
 
@@ -1218,18 +1221,45 @@ public class OicSecurityRealm extends SecurityRealm {
         }
 
         if (isExpired(credentials)) {
+            return handleExpiredToken(user, httpRequest, httpResponse);
+        }
+
+        return true;
+    }
+
+    @VisibleForTesting
+    boolean handleExpiredToken(User user, HttpServletRequest httpRequest, HttpServletResponse httpResponse)
+            throws IOException {
+        Lock lock = USER_REFRESH_LOCKS.get(user.getId());
+        lock.lock();
+        try {
+            OicCredentials credentials = user.getProperty(OicCredentials.class);
+            if (credentials == null || !isExpired(credentials)) {
+                return true;
+            }
+
             if (canRefreshToken(credentials)) {
                 LOGGER.log(Level.FINEST, "Attempting to refresh credential for user: {0}", user.getId());
                 boolean retVal = refreshExpiredToken(user.getId(), credentials, httpRequest, httpResponse);
                 LOGGER.log(Level.FINEST, "Refresh credential for user returned {0}", retVal);
                 return retVal;
             } else if (!isTokenExpirationCheckDisabled()) {
+                LOGGER.log(
+                        Level.FINE,
+                        "Cannot refresh expired OIDC token for user {0}: refreshTokenPresent={1}, providerGrantTypes={2}",
+                        new Object[] {
+                            user.getId(),
+                            !Strings.isNullOrEmpty(credentials.getRefreshToken()),
+                            providerGrantTypesForLog()
+                        });
                 redirectToLoginUrl(httpRequest, httpResponse);
                 return false;
             }
-        }
 
-        return true;
+            return true;
+        } finally {
+            lock.unlock();
+        }
     }
 
     boolean isLogoutRequest(HttpServletRequest request) {
@@ -1258,20 +1288,78 @@ public class OicSecurityRealm extends SecurityRealm {
     }
 
     boolean canRefreshToken(OicCredentials credentials) {
-        boolean hasGrantTypes = getServerConfiguration().toProviderMetadata().getGrantTypes() != null;
-        boolean containsGrantFreshToken = hasGrantTypes
-                && getServerConfiguration().toProviderMetadata().getGrantTypes().contains(GrantType.REFRESH_TOKEN);
         boolean refreshTokenSet = credentials != null && !Strings.isNullOrEmpty(credentials.getRefreshToken());
-        return containsGrantFreshToken && refreshTokenSet;
+        if (!refreshTokenSet) {
+            return false;
+        }
+
+        List<GrantType> grantTypes = getServerConfiguration().toProviderMetadata().getGrantTypes();
+        return grantTypes == null || grantTypes.contains(GrantType.REFRESH_TOKEN);
+    }
+
+    private Object providerGrantTypesForLog() {
+        OicServerConfiguration serverConfiguration = getServerConfiguration();
+        if (serverConfiguration == null) {
+            return null;
+        }
+        try {
+            OIDCProviderMetadata providerMetadata = serverConfiguration.toProviderMetadata();
+            return providerMetadata == null ? null : providerMetadata.getGrantTypes();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.FINER, "Could not read OIDC provider grant types for refresh diagnostic", e);
+            return "unavailable";
+        }
     }
 
     private void redirectToLoginUrl(HttpServletRequest req, HttpServletResponse res) throws IOException {
-        if (req != null && (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization")))) {
-            req.getSession().invalidate();
-        }
         if (res != null) {
-            res.sendRedirect(Jenkins.get().getSecurityRealm().getLoginUrl());
+            if (isNonInteractiveRequest(req)) {
+                res.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+            if (req != null
+                    && (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization")))) {
+                req.getSession().invalidate();
+            }
+            String loginUrl = getLoginUrl();
+            if (!loginUrl.startsWith("/")) {
+                loginUrl = "/" + loginUrl;
+            }
+            if (req != null) {
+                loginUrl = req.getContextPath() + loginUrl;
+            }
+            res.sendRedirect(loginUrl);
         }
+    }
+
+    boolean isNonInteractiveRequest(HttpServletRequest req) {
+        if (req == null) {
+            return false;
+        }
+
+        String requestedWith = req.getHeader("X-Requested-With");
+        if ("XMLHttpRequest".equalsIgnoreCase(requestedWith)) {
+            return true;
+        }
+
+        String secFetchDest = req.getHeader("Sec-Fetch-Dest");
+        if (secFetchDest != null
+                && !"document".equalsIgnoreCase(secFetchDest)
+                && !"iframe".equalsIgnoreCase(secFetchDest)) {
+            return true;
+        }
+
+        String accept = req.getHeader("Accept");
+        if (accept != null && !accept.contains("text/html") && !accept.contains("application/xhtml+xml")) {
+            return true;
+        }
+
+        String uri = req.getRequestURI();
+        if (uri != null && uri.contains("/ajax")) {
+            return true;
+        }
+
+        return req.getHeader("Jenkins-Crumb") != null;
     }
 
     public boolean isExpired(OicCredentials credentials) {
@@ -1282,7 +1370,7 @@ public class OicSecurityRealm extends SecurityRealm {
         return CLOCK.millis() >= credentials.getExpiresAtMillis();
     }
 
-    private boolean refreshExpiredToken(
+    boolean refreshExpiredToken(
             String expectedUsername,
             OicCredentials credentials,
             HttpServletRequest httpRequest,
@@ -1372,6 +1460,7 @@ public class OicSecurityRealm extends SecurityRealm {
                     return false;
                 }
                 LOGGER.log(Level.FINE, "Failed to refresh expired token", e);
+                expireCredentials(expectedUsername);
                 redirectToLoginUrl(httpRequest, httpResponse);
                 return false;
             }
@@ -1390,6 +1479,14 @@ public class OicSecurityRealm extends SecurityRealm {
             // could not renew
             httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return false;
+        }
+    }
+
+    @VisibleForTesting
+    void expireCredentials(String userId) throws IOException {
+        User user = User.getById(userId, false);
+        if (user != null) {
+            user.addProperty(new OicCredentials(null, null, null, CLOCK.millis()));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
@@ -1,10 +1,16 @@
 package org.jenkinsci.plugins.oic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.nimbusds.oauth2.sdk.GrantType;
@@ -12,11 +18,20 @@ import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import hudson.model.User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.time.Clock;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.security.ApiTokenProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -158,5 +173,148 @@ public class OicSecurityRealmTokenExpirationTest {
 
         when(mockOicCredentials.getRefreshToken()).thenReturn("refreshToken");
         assertTrue(realm.canRefreshToken(mockOicCredentials));
+
+        when(mockOIDCProviderMetadata.getGrantTypes()).thenReturn(null);
+        assertTrue(realm.canRefreshToken(mockOicCredentials));
+    }
+
+    @Test
+    void handleExpiredToken_concurrentRefreshOnlyRefreshesOnce() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(true);
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+        OicCredentials refreshedCredentials = mock(OicCredentials.class);
+        when(refreshedCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() + 60_000);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("concurrent-refresh-user");
+
+        AtomicBoolean refreshed = new AtomicBoolean(false);
+        when(user.getProperty(OicCredentials.class))
+                .thenAnswer(invocation -> refreshed.get() ? refreshedCredentials : expiredCredentials);
+
+        CountDownLatch refreshStarted = new CountDownLatch(1);
+        CountDownLatch releaseRefresh = new CountDownLatch(1);
+        AtomicInteger refreshCount = new AtomicInteger();
+        when(realm.refreshExpiredToken(anyString(), any(), any(), any())).thenAnswer(invocation -> {
+            refreshCount.incrementAndGet();
+            refreshStarted.countDown();
+            assertTrue(releaseRefresh.await(5, TimeUnit.SECONDS));
+            refreshed.set(true);
+            return true;
+        });
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> first = executor.submit(() -> realm.handleExpiredToken(user, request, response));
+            assertTrue(refreshStarted.await(5, TimeUnit.SECONDS));
+
+            Future<Boolean> second = executor.submit(() -> realm.handleExpiredToken(user, request, response));
+            TimeUnit.MILLISECONDS.sleep(100);
+
+            releaseRefresh.countDown();
+
+            assertTrue(first.get(5, TimeUnit.SECONDS));
+            assertTrue(second.get(5, TimeUnit.SECONDS));
+        } finally {
+            releaseRefresh.countDown();
+            executor.shutdownNow();
+        }
+
+        assertEquals(1, refreshCount.get());
+        verify(realm, times(1)).refreshExpiredToken(anyString(), any(), any(), any());
+    }
+
+    @Test
+    void handleExpiredToken_redirectsToRootRelativeLoginUrl() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+        when(realm.getLoginUrl()).thenCallRealMethod();
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("redirect-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpSession session = mock(HttpSession.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getSession()).thenReturn(session);
+        when(request.getContextPath()).thenReturn("");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, request, response));
+
+        verify(session).invalidate();
+        verify(response).sendRedirect("/securityRealm/commenceLogin");
+    }
+
+    @Test
+    void handleExpiredToken_nonInteractiveRequestReturnsUnauthorizedInsteadOfRedirect() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("ajax-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpSession session = mock(HttpSession.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getRequestURI()).thenReturn("/widget/BuildQueueWidget/ajax");
+        when(request.getHeader("Sec-Fetch-Dest")).thenReturn("empty");
+        when(request.getHeader("Accept")).thenReturn("*/*");
+        when(request.getHeader("Jenkins-Crumb")).thenReturn("crumb");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, request, response));
+
+        verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(response, never()).sendRedirect(anyString());
+        verify(session, never()).invalidate();
+    }
+
+    @Test
+    void expireCredentials_replacesCredentialsWithExpiredEmptyTokens() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        doCallRealMethod().when(realm).expireCredentials(anyString());
+
+        User user = mock(User.class);
+        try (MockedStatic<User> userMocked = mockStatic(User.class)) {
+            userMocked.when(() -> User.getById("expired-user", false)).thenReturn(user);
+
+            realm.expireCredentials("expired-user");
+        }
+
+        ArgumentCaptor<OicCredentials> credentials = ArgumentCaptor.forClass(OicCredentials.class);
+        verify(user).addProperty(credentials.capture());
+
+        OicCredentials expiredCredentials = credentials.getValue();
+        assertFalse(expiredCredentials.getAccessToken() != null && !expiredCredentials.getAccessToken()
+                .isEmpty());
+        assertFalse(expiredCredentials.getIdToken() != null && !expiredCredentials.getIdToken()
+                .isEmpty());
+        assertFalse(expiredCredentials.getRefreshToken() != null && !expiredCredentials.getRefreshToken()
+                .isEmpty());
+        assertTrue(expiredCredentials.getExpiresAtMillis() <= Clock.systemUTC().millis());
     }
 }


### PR DESCRIPTION
# Fix OIDC token refresh storms and AJAX login redirects

## Summary

This PR fixes several related failure modes in the OIDC access-token expiration path:

- refresh is now attempted when a user has a stored refresh token and provider metadata omits `grant_types_supported`;
- concurrent requests for the same user now serialize refresh attempts so only one request refreshes the token;
- non-interactive requests no longer receive browser-login redirects when refresh is unavailable or fails;
- `invalid_grant` refresh failures now expire stored OIDC credentials so repeated AJAX polling does not keep retrying a known-invalid refresh token;
- interactive fallback login redirects now use a root-relative Jenkins login URL.

Together these changes prevent periodic browser refresh storms, stale Jenkins crumb loops, and browser CORS failures caused by AJAX requests being redirected into the OIDC provider authorization endpoint.

## Problem

`OicSecurityRealm` checks the stored OIDC access token on every request. When the access token is expired, the intended flow is:

1. detect the expired `OicCredentials`;
2. silently refresh the OIDC profile with the stored refresh token;
3. update the user's `OicCredentials`;
4. continue the original request without user-visible interruption.

In practice, several edge cases made Jenkins fall back to interactive login too aggressively.

### Provider metadata can omit grant types

The previous `canRefreshToken` implementation required both:

- a non-empty stored refresh token; and
- provider metadata whose grant types explicitly contain `refresh_token`.

On the affected Jenkins deployment, the user did have a refresh token, but `toProviderMetadata().getGrantTypes()` returned `null`:

```text
refreshTokenPresent=true
refreshTokenLength=834
grantTypes=null
```

Because `grantTypes` was `null`, the plugin decided refresh was unsupported and redirected to login on every access-token expiry. This caused full OIDC login round-trips even though Jenkins had all the data needed to try a refresh.

The patched logic treats a missing grant-type list as "not explicitly disallowed". If a refresh token is stored, the plugin attempts refresh when grant types are absent. If grant types are present and explicitly do not include `refresh_token`, refresh remains disabled.

### Multiple requests can race on the same expired credentials

Jenkins pages often issue several near-simultaneous requests: the main page, widgets, AJAX polling, Blue Ocean endpoints, etc. When an access token expires, many requests for the same user can observe the same expired `OicCredentials` at the same time.

Without coordination, multiple requests can attempt to use the same refresh token. With providers that rotate or invalidate refresh tokens, this creates a race:

1. request A refreshes successfully and stores new credentials;
2. request B attempts refresh with the old token;
3. provider rejects request B with `invalid_grant`;
4. plugin falls back to interactive login and may invalidate the session that request A just recovered.

This PR adds a per-user refresh lock. After acquiring the lock, each request re-reads the user's current `OicCredentials`. If another request already refreshed the token, later requests see fresh credentials and skip refresh.

### AJAX requests should not be redirected to interactive login

When refresh is unavailable or fails, the old fallback always called `redirectToLoginUrl`. This is correct for a normal browser navigation, but bad for AJAX and widget requests.

For non-interactive requests, redirecting to login causes browser-side problems:

- Jenkins widget AJAX receives a redirect instead of an application response;
- if the request includes `Jenkins-Crumb`, the browser may preflight the cross-origin redirect to the OIDC provider authorization endpoint;
- the OIDC provider authorization endpoint is not a CORS API endpoint, so the preflight can fail with `405 Method Not Allowed`;
- after session invalidation, the page's old crumb becomes stale and widget polling can continue returning `403`.

This PR detects non-interactive requests using common request signals:

- `X-Requested-With: XMLHttpRequest`;
- `Sec-Fetch-Dest` values other than `document` and `iframe`;
- `Accept` headers that do not accept HTML;
- Jenkins `/ajax` request paths;
- requests carrying `Jenkins-Crumb`.

For these requests, the plugin returns `401 Unauthorized` instead of redirecting to interactive login. Normal page navigations still use the interactive login redirect.

### Relative login redirects can resolve under the wrong path

`getLoginUrl()` returns `securityRealm/commenceLogin`, which is relative. Returning that directly from a nested request such as `/widget/BuildQueueWidget/ajax` can make the browser resolve it under the widget path.

This PR normalizes interactive login redirects to a root-relative Jenkins URL:

```text
/securityRealm/commenceLogin
```

When Jenkins is deployed under a context path, the context path is preserved.

### Invalid refresh tokens should not be retried forever by polling requests

If the refresh token itself expires or is revoked, the provider can return `invalid_grant`. Returning `401` for AJAX requests avoids the browser CORS redirect, but leaving the old refresh token in `OicCredentials` would make every subsequent widget poll attempt the same failed refresh again.

This PR expires the stored OIDC credentials when refresh fails with `invalid_grant`. The next non-interactive request can then return `401` without repeatedly calling the token endpoint with a known-invalid refresh token. A later interactive browser navigation will still send the user through normal login.

## Changes

### `OicSecurityRealm`

- Added a striped per-user refresh lock:

```java
private static final Striped<Lock> USER_REFRESH_LOCKS = Striped.lazyWeakLock(64);
```

- Split expired-token handling into `handleExpiredToken(...)` so refresh is serialized by user ID and credentials are re-read after the lock is acquired.
- Changed `canRefreshToken(...)`:
  - still requires a non-empty refresh token;
  - allows refresh when provider grant types are `null`;
  - still rejects refresh when provider grant types are present and do not contain `refresh_token`.
- Added a small FINE-level diagnostic when refresh cannot be attempted, including whether a refresh token is present and what provider grant types were seen. No token values are logged.
- Changed interactive fallback redirects to build a root-relative login URL.
- Added non-interactive request detection and return `401 Unauthorized` for those requests instead of redirecting to login.
- On `invalid_grant`, expired stored OIDC credentials are written for the user before fallback handling. This prevents repeated refresh attempts with a known-invalid refresh token.
- Made `refreshExpiredToken(...)` and the small helper methods package-visible where needed for focused unit tests.

### Tests

`OicSecurityRealmTokenExpirationTest` now covers:

- refresh is allowed when grant types are `null` and a refresh token exists;
- refresh is still rejected when grant types explicitly omit `refresh_token`;
- concurrent expired-token handling refreshes only once for the same user;
- interactive fallback redirects to `/securityRealm/commenceLogin`;
- non-interactive expired-token fallback returns `401` and does not redirect;
- invalid refresh credentials are replaced with expired empty credentials.

## Runtime Validation

The patch was tested on a Jenkins 2.541.2 deployment with a patched `oic-auth` JPI.

Script Console confirmed the patched class was loaded:

```groovy
def cls = Jenkins.instance.pluginManager.uberClassLoader.loadClass("org.jenkinsci.plugins.oic.OicSecurityRealm")
println cls.declaredMethods*.name.findAll { it == "isNonInteractiveRequest" }
```

Result:

```text
[isNonInteractiveRequest]
```

The deployment had this token state:

```text
refreshTokenPresent=true
refreshTokenLength=834
grantTypes=null
```

Before the final `canRefreshToken` change, this state caused fallback login redirects. After the change:

```groovy
import hudson.model.User
import org.jenkinsci.plugins.oic.OicCredentials

def realm = Jenkins.instance.securityRealm
def c = User.getById("scheremisin", false).getProperty(OicCredentials)
def m = realm.class.getDeclaredMethod("canRefreshToken", OicCredentials)
m.accessible = true
println "canRefresh=${m.invoke(realm, c)}"
```

Result:

```text
canRefresh=true
```

After deployment, Jenkins was able to continue using the page after token expiry without the earlier Keycloak CORS preflight failure or repeated widget crumb storm.

## Validation

Local validation command:

```bash
MAVEN_OPTS=-Duser.home=/private/tmp/oic-mvn-home \
  /opt/homebrew/bin/mvn \
  -Dmaven.repo.local=/Users/scheremisin/.m2/repository \
  -Dtest=OicSecurityRealmTokenExpirationTest \
  test package
```

Result:

```text
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Compatibility and Risk

- API-token requests are not changed. `handleTokenExpiration` still returns early for valid Jenkins API-token requests when that setting is enabled.
- Providers that explicitly publish grant types without `refresh_token` still do not refresh.
- Providers that omit grant types can now refresh if Jenkins already has a refresh token.
- Interactive browser navigation still redirects to the normal Jenkins login endpoint.
- Non-interactive requests now receive `401` instead of an OIDC login redirect. This is intentional because AJAX callers cannot complete an interactive OIDC authorization-code flow safely.
- If a refresh token has expired due to provider session limits, the user still needs to log in again. The change is that AJAX/widget requests fail cleanly instead of being redirected cross-site into the OIDC provider.



<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
