### PR TITLE
Treat absent grant_types_supported as refresh-capable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1258,11 +1258,17 @@ public class OicSecurityRealm extends SecurityRealm {
     }
 
     boolean canRefreshToken(OicCredentials credentials) {
-        boolean hasGrantTypes = getServerConfiguration().toProviderMetadata().getGrantTypes() != null;
-        boolean containsGrantFreshToken = hasGrantTypes
-                && getServerConfiguration().toProviderMetadata().getGrantTypes().contains(GrantType.REFRESH_TOKEN);
         boolean refreshTokenSet = credentials != null && !Strings.isNullOrEmpty(credentials.getRefreshToken());
-        return containsGrantFreshToken && refreshTokenSet;
+        if (!refreshTokenSet) {
+            return false;
+        }
+
+        // Some providers (notably Keycloak with default discovery output) do not advertise grant_types_supported,
+        // so toProviderMetadata().getGrantTypes() returns null even when refresh_token is in fact supported.
+        // Treat a null/absent grant_types_supported as "not advertised, do not refuse refresh"; only reject when
+        // the provider explicitly publishes a list that omits refresh_token.
+        List<GrantType> grantTypes = getServerConfiguration().toProviderMetadata().getGrantTypes();
+        return grantTypes == null || grantTypes.contains(GrantType.REFRESH_TOKEN);
     }
 
     private void redirectToLoginUrl(HttpServletRequest req, HttpServletResponse res) throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
@@ -158,5 +158,10 @@ public class OicSecurityRealmTokenExpirationTest {
 
         when(mockOicCredentials.getRefreshToken()).thenReturn("refreshToken");
         assertTrue(realm.canRefreshToken(mockOicCredentials));
+
+        // Provider that does not advertise grant_types_supported (e.g. Keycloak default discovery)
+        // must not block refresh when a refresh token is already stored.
+        when(mockOIDCProviderMetadata.getGrantTypes()).thenReturn(null);
+        assertTrue(realm.canRefreshToken(mockOicCredentials));
     }
 }


### PR DESCRIPTION
Some OIDC providers (notably Keycloak with default discovery output) return no grant_types_supported in their discovery metadata, in which case OIDCProviderMetadata.getGrantTypes() yields null. The previous canRefreshToken() logic interpreted that as "refresh is not supported" and forced an interactive login even though a real refresh token had been issued and stored in OicCredentials.

Reverse the predicate: require a refresh token to be present, and only refuse refresh when the provider explicitly publishes a grant types list that omits refresh_token. A null/absent list is treated as "not advertised" rather than "unsupported", which matches the OIDC discovery spec (grant_types_supported is optional and defaults to authorization_code and implicit being supported).

Extend the existing canRefreshToken unit test to cover the null grant types branch.

<!-- Please describe your pull request here. -->
