### PR TITLE
Fix expiration check for well-known configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicServerWellKnownConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicServerWellKnownConfiguration.java
@@ -86,7 +86,7 @@ public class OicServerWellKnownConfiguration extends OicServerConfiguration {
         // so that we can cache and expire the result.
         // pac4j will cache the result yet never expire it.
         LocalDateTime now = LocalDateTime.now();
-        if (this.wellKnownExpires != null && this.wellKnownExpires.isBefore(now)) {
+        if (this.wellKnownExpires != null && this.wellKnownExpires.isAfter(now)) {
             // configuration is still fresh
             return oidcProviderMetadata;
         }


### PR DESCRIPTION
While investigating for issue https://github.com/jenkinsci/oic-auth-plugin/issues/757, I found that the logic here is inverted. `wellKnownExpires.isBefore(now)` is true when the expiry has passed (cache stale). So the config is re-downloaded on every call until 1h after first load, then sticks with the cached copy forever.

<!-- Please describe your pull request here. -->

### Testing done

Not covered.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] ~Link to relevant issues in GitHub or Jira~
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] ~Ensure you have provided tests that demonstrate the feature works or the issue is fixed~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
