### PR TITLE
Apply oic connection timeout configs to nimbusds requests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/CustomOidcConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/CustomOidcConfiguration.java
@@ -10,6 +10,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import jenkins.model.Jenkins;
 import jenkins.security.FIPS140;
+import jenkins.util.SystemProperties;
 import org.jenkinsci.plugins.oic.ssl.IgnoringHostNameVerifier;
 import org.jenkinsci.plugins.oic.ssl.TLSUtils;
 import org.pac4j.oidc.config.OidcConfiguration;
@@ -18,6 +19,12 @@ import org.pac4j.oidc.config.OidcConfiguration;
  * An OidcConfiguration that will customize {@link HttpRequest} with the Jenkins proxy, and iff TLS is disabled a lenient {@link HostnameVerifier} and {@link SSLContext}.
  */
 class CustomOidcConfiguration extends OidcConfiguration {
+
+    @SuppressWarnings("boxing")
+    private static final int CONNECTION_TIMEOUT_MS = SystemProperties.getInteger("OIC_CONNECTION_TIMEOUT_MS", 2_000);
+
+    @SuppressWarnings("boxing")
+    private static final int READ_TIMEOUT_MS = SystemProperties.getInteger("OIC_CONNECTION_READ_TIMEOUT_MS", 5_000);
 
     private final boolean disableTLS;
 
@@ -31,6 +38,8 @@ class CustomOidcConfiguration extends OidcConfiguration {
     @Override
     public void configureHttpRequest(HTTPRequest request) {
         super.configureHttpRequest(request);
+        request.setConnectTimeout(CONNECTION_TIMEOUT_MS);
+        request.setReadTimeout(READ_TIMEOUT_MS);
         Proxy proxy = null;
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) { // unit tests


### PR DESCRIPTION
There are several open tickets about the timeout issue, so I didn't open a new one.

I copied the timeout config from ProxyAwareResourceRetriever.java to CustomOidcConfiguration.java

The oidc connection happens with multiple routes. ProxyAwareResourceRetriever.java can be configured with system properties OIC_CONNECTION_TIMEOUT_MS and OIC_CONNECTION_READ_TIMEOUT_MS, but CustomOidcConfiguration.java don't read these properties. If a slow IdP is used, the login will success in the first round but failed to refresh the token in the next round.

### Our use case

The reason why we are hitting this issue is that we are deploying IdP (keycloak) in a serverless environment (Google Cloud Run). That means the IdP will power off if no requests come in after 5 seconds. The power on will take 10 seconds. Set OIC_CONNECTION_READ_TIMEOUT_MS is acceptable for the browser login. However, if the auth request comes from github webhook, it only triggers refresh token flow without timeout configured, and it will hit a read timeout in CustomOidcConfiguration.java

### Testing done

We trust jenkins-ci :)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

### Notes

This PR is drafted with the help from Claude Opus 4.6

Fix: #722 
Fix: #477 
