### PR TITLE
Harden OIDC token refresh and callback recovery

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1301,7 +1301,8 @@ public class OicSecurityRealm extends SecurityRealm {
             return false;
         }
 
-        List<GrantType> grantTypes = getServerConfiguration().toProviderMetadata().getGrantTypes();
+        List<GrantType> grantTypes =
+                getServerConfiguration().toProviderMetadata().getGrantTypes();
         return grantTypes == null || grantTypes.contains(GrantType.REFRESH_TOKEN);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -128,6 +128,8 @@ import org.pac4j.jee.http.adapter.JEEHttpActionAdapter;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.authenticator.OidcAuthenticator;
+import org.pac4j.oidc.exceptions.OidcMissingSessionStateException;
+import org.pac4j.oidc.exceptions.OidcStateMismatchException;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.redirect.OidcRedirectionActionBuilder;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -1190,6 +1192,12 @@ public class OicSecurityRealm extends SecurityRealm {
         } catch (HttpAction e) {
             // this may be an OK flow for logout login is handled upstream.
             JEEHttpActionAdapter.INSTANCE.adapt(e, webContext);
+        } catch (OidcMissingSessionStateException | OidcStateMismatchException e) {
+            LOGGER.log(
+                    Level.FINE,
+                    "Restarting OpenID Connect login after callback state validation failed: {0}",
+                    e.getClass().getSimpleName());
+            redirectToLoginUrl(request, response);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.oic;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.Striped;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.GrantType;
@@ -80,6 +81,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -150,6 +152,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OicSecurityRealm extends SecurityRealm {
 
     private static final Logger LOGGER = Logger.getLogger(OicSecurityRealm.class.getName());
+    private static final Striped<Lock> USER_REFRESH_LOCKS = Striped.lazyWeakLock(64);
     private IdStrategy userIdStrategy;
     private IdStrategy groupIdStrategy;
 
@@ -1218,18 +1221,45 @@ public class OicSecurityRealm extends SecurityRealm {
         }
 
         if (isExpired(credentials)) {
+            return handleExpiredToken(user, httpRequest, httpResponse);
+        }
+
+        return true;
+    }
+
+    @VisibleForTesting
+    boolean handleExpiredToken(User user, HttpServletRequest httpRequest, HttpServletResponse httpResponse)
+            throws IOException {
+        Lock lock = USER_REFRESH_LOCKS.get(user.getId());
+        lock.lock();
+        try {
+            OicCredentials credentials = user.getProperty(OicCredentials.class);
+            if (credentials == null || !isExpired(credentials)) {
+                return true;
+            }
+
             if (canRefreshToken(credentials)) {
                 LOGGER.log(Level.FINEST, "Attempting to refresh credential for user: {0}", user.getId());
                 boolean retVal = refreshExpiredToken(user.getId(), credentials, httpRequest, httpResponse);
                 LOGGER.log(Level.FINEST, "Refresh credential for user returned {0}", retVal);
                 return retVal;
             } else if (!isTokenExpirationCheckDisabled()) {
+                LOGGER.log(
+                        Level.FINE,
+                        "Cannot refresh expired OIDC token for user {0}: refreshTokenPresent={1}, providerGrantTypes={2}",
+                        new Object[] {
+                            user.getId(),
+                            !Strings.isNullOrEmpty(credentials.getRefreshToken()),
+                            providerGrantTypesForLog()
+                        });
                 redirectToLoginUrl(httpRequest, httpResponse);
                 return false;
             }
-        }
 
-        return true;
+            return true;
+        } finally {
+            lock.unlock();
+        }
     }
 
     boolean isLogoutRequest(HttpServletRequest request) {
@@ -1258,20 +1288,78 @@ public class OicSecurityRealm extends SecurityRealm {
     }
 
     boolean canRefreshToken(OicCredentials credentials) {
-        boolean hasGrantTypes = getServerConfiguration().toProviderMetadata().getGrantTypes() != null;
-        boolean containsGrantFreshToken = hasGrantTypes
-                && getServerConfiguration().toProviderMetadata().getGrantTypes().contains(GrantType.REFRESH_TOKEN);
         boolean refreshTokenSet = credentials != null && !Strings.isNullOrEmpty(credentials.getRefreshToken());
-        return containsGrantFreshToken && refreshTokenSet;
+        if (!refreshTokenSet) {
+            return false;
+        }
+
+        List<GrantType> grantTypes = getServerConfiguration().toProviderMetadata().getGrantTypes();
+        return grantTypes == null || grantTypes.contains(GrantType.REFRESH_TOKEN);
+    }
+
+    private Object providerGrantTypesForLog() {
+        OicServerConfiguration serverConfiguration = getServerConfiguration();
+        if (serverConfiguration == null) {
+            return null;
+        }
+        try {
+            OIDCProviderMetadata providerMetadata = serverConfiguration.toProviderMetadata();
+            return providerMetadata == null ? null : providerMetadata.getGrantTypes();
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.FINER, "Could not read OIDC provider grant types for refresh diagnostic", e);
+            return "unavailable";
+        }
     }
 
     private void redirectToLoginUrl(HttpServletRequest req, HttpServletResponse res) throws IOException {
-        if (req != null && (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization")))) {
-            req.getSession().invalidate();
-        }
         if (res != null) {
-            res.sendRedirect(Jenkins.get().getSecurityRealm().getLoginUrl());
+            if (isNonInteractiveRequest(req)) {
+                res.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+            if (req != null
+                    && (req.getSession(false) != null || Strings.isNullOrEmpty(req.getHeader("Authorization")))) {
+                req.getSession().invalidate();
+            }
+            String loginUrl = getLoginUrl();
+            if (!loginUrl.startsWith("/")) {
+                loginUrl = "/" + loginUrl;
+            }
+            if (req != null) {
+                loginUrl = req.getContextPath() + loginUrl;
+            }
+            res.sendRedirect(loginUrl);
         }
+    }
+
+    boolean isNonInteractiveRequest(HttpServletRequest req) {
+        if (req == null) {
+            return false;
+        }
+
+        String requestedWith = req.getHeader("X-Requested-With");
+        if ("XMLHttpRequest".equalsIgnoreCase(requestedWith)) {
+            return true;
+        }
+
+        String secFetchDest = req.getHeader("Sec-Fetch-Dest");
+        if (secFetchDest != null
+                && !"document".equalsIgnoreCase(secFetchDest)
+                && !"iframe".equalsIgnoreCase(secFetchDest)) {
+            return true;
+        }
+
+        String accept = req.getHeader("Accept");
+        if (accept != null && !accept.contains("text/html") && !accept.contains("application/xhtml+xml")) {
+            return true;
+        }
+
+        String uri = req.getRequestURI();
+        if (uri != null && uri.contains("/ajax")) {
+            return true;
+        }
+
+        return req.getHeader("Jenkins-Crumb") != null;
     }
 
     public boolean isExpired(OicCredentials credentials) {
@@ -1282,7 +1370,7 @@ public class OicSecurityRealm extends SecurityRealm {
         return CLOCK.millis() >= credentials.getExpiresAtMillis();
     }
 
-    private boolean refreshExpiredToken(
+    boolean refreshExpiredToken(
             String expectedUsername,
             OicCredentials credentials,
             HttpServletRequest httpRequest,
@@ -1372,6 +1460,7 @@ public class OicSecurityRealm extends SecurityRealm {
                     return false;
                 }
                 LOGGER.log(Level.FINE, "Failed to refresh expired token", e);
+                expireCredentials(expectedUsername);
                 redirectToLoginUrl(httpRequest, httpResponse);
                 return false;
             }
@@ -1390,6 +1479,14 @@ public class OicSecurityRealm extends SecurityRealm {
             // could not renew
             httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return false;
+        }
+    }
+
+    @VisibleForTesting
+    void expireCredentials(String userId) throws IOException {
+        User user = User.getById(userId, false);
+        if (user != null) {
+            user.addProperty(new OicCredentials(null, null, null, CLOCK.millis()));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/OicSecurityRealm.java
@@ -1311,8 +1311,7 @@ public class OicSecurityRealm extends SecurityRealm {
             return null;
         }
         try {
-            OIDCProviderMetadata providerMetadata = serverConfiguration.toProviderMetadata();
-            return providerMetadata == null ? null : providerMetadata.getGrantTypes();
+            return serverConfiguration.toProviderMetadata().getGrantTypes();
         } catch (RuntimeException e) {
             LOGGER.log(Level.FINER, "Could not read OIDC provider grant types for refresh diagnostic", e);
             return "unavailable";

--- a/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
@@ -186,9 +186,11 @@ public class OicSecurityRealmTokenExpirationTest {
         when(realm.canRefreshToken(any())).thenReturn(true);
 
         OicCredentials expiredCredentials = mock(OicCredentials.class);
-        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
         OicCredentials refreshedCredentials = mock(OicCredentials.class);
-        when(refreshedCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() + 60_000);
+        when(refreshedCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() + 60_000);
 
         User user = mock(User.class);
         when(user.getId()).thenReturn("concurrent-refresh-user");
@@ -242,7 +244,8 @@ public class OicSecurityRealmTokenExpirationTest {
         when(realm.getLoginUrl()).thenCallRealMethod();
 
         OicCredentials expiredCredentials = mock(OicCredentials.class);
-        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
 
         User user = mock(User.class);
         when(user.getId()).thenReturn("redirect-user");
@@ -271,7 +274,8 @@ public class OicSecurityRealmTokenExpirationTest {
         when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
 
         OicCredentials expiredCredentials = mock(OicCredentials.class);
-        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
 
         User user = mock(User.class);
         when(user.getId()).thenReturn("ajax-user");
@@ -309,12 +313,12 @@ public class OicSecurityRealmTokenExpirationTest {
         verify(user).addProperty(credentials.capture());
 
         OicCredentials expiredCredentials = credentials.getValue();
-        assertFalse(expiredCredentials.getAccessToken() != null && !expiredCredentials.getAccessToken()
-                .isEmpty());
-        assertFalse(expiredCredentials.getIdToken() != null && !expiredCredentials.getIdToken()
-                .isEmpty());
-        assertFalse(expiredCredentials.getRefreshToken() != null && !expiredCredentials.getRefreshToken()
-                .isEmpty());
+        assertFalse(expiredCredentials.getAccessToken() != null
+                && !expiredCredentials.getAccessToken().isEmpty());
+        assertFalse(expiredCredentials.getIdToken() != null
+                && !expiredCredentials.getIdToken().isEmpty());
+        assertFalse(expiredCredentials.getRefreshToken() != null
+                && !expiredCredentials.getRefreshToken().isEmpty());
         assertTrue(expiredCredentials.getExpiresAtMillis() <= Clock.systemUTC().millis());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
@@ -1,10 +1,16 @@
 package org.jenkinsci.plugins.oic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.nimbusds.oauth2.sdk.GrantType;
@@ -12,11 +18,20 @@ import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import hudson.model.User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.time.Clock;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.security.ApiTokenProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -158,5 +173,148 @@ public class OicSecurityRealmTokenExpirationTest {
 
         when(mockOicCredentials.getRefreshToken()).thenReturn("refreshToken");
         assertTrue(realm.canRefreshToken(mockOicCredentials));
+
+        when(mockOIDCProviderMetadata.getGrantTypes()).thenReturn(null);
+        assertTrue(realm.canRefreshToken(mockOicCredentials));
+    }
+
+    @Test
+    void handleExpiredToken_concurrentRefreshOnlyRefreshesOnce() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(true);
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+        OicCredentials refreshedCredentials = mock(OicCredentials.class);
+        when(refreshedCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() + 60_000);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("concurrent-refresh-user");
+
+        AtomicBoolean refreshed = new AtomicBoolean(false);
+        when(user.getProperty(OicCredentials.class))
+                .thenAnswer(invocation -> refreshed.get() ? refreshedCredentials : expiredCredentials);
+
+        CountDownLatch refreshStarted = new CountDownLatch(1);
+        CountDownLatch releaseRefresh = new CountDownLatch(1);
+        AtomicInteger refreshCount = new AtomicInteger();
+        when(realm.refreshExpiredToken(anyString(), any(), any(), any())).thenAnswer(invocation -> {
+            refreshCount.incrementAndGet();
+            refreshStarted.countDown();
+            assertTrue(releaseRefresh.await(5, TimeUnit.SECONDS));
+            refreshed.set(true);
+            return true;
+        });
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> first = executor.submit(() -> realm.handleExpiredToken(user, request, response));
+            assertTrue(refreshStarted.await(5, TimeUnit.SECONDS));
+
+            Future<Boolean> second = executor.submit(() -> realm.handleExpiredToken(user, request, response));
+            TimeUnit.MILLISECONDS.sleep(100);
+
+            releaseRefresh.countDown();
+
+            assertTrue(first.get(5, TimeUnit.SECONDS));
+            assertTrue(second.get(5, TimeUnit.SECONDS));
+        } finally {
+            releaseRefresh.countDown();
+            executor.shutdownNow();
+        }
+
+        assertEquals(1, refreshCount.get());
+        verify(realm, times(1)).refreshExpiredToken(anyString(), any(), any(), any());
+    }
+
+    @Test
+    void handleExpiredToken_redirectsToRootRelativeLoginUrl() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+        when(realm.getLoginUrl()).thenCallRealMethod();
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("redirect-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpSession session = mock(HttpSession.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getSession()).thenReturn(session);
+        when(request.getContextPath()).thenReturn("");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, request, response));
+
+        verify(session).invalidate();
+        verify(response).sendRedirect("/securityRealm/commenceLogin");
+    }
+
+    @Test
+    void handleExpiredToken_nonInteractiveRequestReturnsUnauthorizedInsteadOfRedirect() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() - 10);
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("ajax-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpSession session = mock(HttpSession.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getRequestURI()).thenReturn("/widget/BuildQueueWidget/ajax");
+        when(request.getHeader("Sec-Fetch-Dest")).thenReturn("empty");
+        when(request.getHeader("Accept")).thenReturn("*/*");
+        when(request.getHeader("Jenkins-Crumb")).thenReturn("crumb");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, request, response));
+
+        verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(response, never()).sendRedirect(anyString());
+        verify(session, never()).invalidate();
+    }
+
+    @Test
+    void expireCredentials_replacesCredentialsWithExpiredEmptyTokens() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        doCallRealMethod().when(realm).expireCredentials(anyString());
+
+        User user = mock(User.class);
+        try (MockedStatic<User> userMocked = mockStatic(User.class)) {
+            userMocked.when(() -> User.getById("expired-user", false)).thenReturn(user);
+
+            realm.expireCredentials("expired-user");
+        }
+
+        ArgumentCaptor<OicCredentials> credentials = ArgumentCaptor.forClass(OicCredentials.class);
+        verify(user).addProperty(credentials.capture());
+
+        OicCredentials expiredCredentials = credentials.getValue();
+        assertFalse(expiredCredentials.getAccessToken() != null && !expiredCredentials.getAccessToken()
+                .isEmpty());
+        assertFalse(expiredCredentials.getIdToken() != null && !expiredCredentials.getIdToken()
+                .isEmpty());
+        assertFalse(expiredCredentials.getRefreshToken() != null && !expiredCredentials.getRefreshToken()
+                .isEmpty());
+        assertTrue(expiredCredentials.getExpiresAtMillis() <= Clock.systemUTC().millis());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
@@ -234,6 +234,70 @@ public class OicSecurityRealmTokenExpirationTest {
     }
 
     @Test
+    void handleTokenExpiration_expiredCredentialsDelegateToLockedRefreshPath() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.isLogoutRequest(any())).thenCallRealMethod();
+        when(realm.handleTokenExpiration(any(), any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
+        User user = mock(User.class);
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/job/example/");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(realm.handleExpiredToken(user, request, response)).thenReturn(false);
+
+        try (MockedStatic<User> userMocked = mockStatic(User.class)) {
+            userMocked.when(() -> User.get2(any())).thenReturn(user);
+
+            assertFalse(realm.handleTokenExpiration(request, response));
+        }
+
+        verify(realm).handleExpiredToken(user, request, response);
+    }
+
+    @Test
+    void handleExpiredToken_returnsWhenCredentialsDisappearOrAreAlreadyFresh() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("fresh-after-lock-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(null);
+        assertTrue(realm.handleExpiredToken(user, null, null));
+
+        OicCredentials freshCredentials = mock(OicCredentials.class);
+        when(freshCredentials.getExpiresAtMillis()).thenReturn(Clock.systemUTC().millis() + 60_000);
+        when(user.getProperty(OicCredentials.class)).thenReturn(freshCredentials);
+        assertTrue(realm.handleExpiredToken(user, null, null));
+
+        verify(realm, never()).refreshExpiredToken(anyString(), any(), any(), any());
+    }
+
+    @Test
+    void handleExpiredToken_allowsExpiredTokenWhenExpirationCheckDisabled() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(true);
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("disabled-expiration-check-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        assertTrue(realm.handleExpiredToken(user, null, null));
+    }
+
+    @Test
     void handleExpiredToken_redirectsToRootRelativeLoginUrl() throws Exception {
         OicSecurityRealm realm = mock(OicSecurityRealm.class);
         when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
@@ -262,6 +326,40 @@ public class OicSecurityRealmTokenExpirationTest {
 
         verify(session).invalidate();
         verify(response).sendRedirect("/securityRealm/commenceLogin");
+    }
+
+    @Test
+    void handleExpiredToken_preservesContextPathForRootRelativeLoginUrl() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+        when(realm.getLoginUrl()).thenReturn("/securityRealm/commenceLogin");
+
+        OicServerConfiguration serverConfiguration = mock(OicServerConfiguration.class);
+        when(serverConfiguration.toProviderMetadata()).thenThrow(new IllegalStateException("metadata unavailable"));
+        when(realm.getServerConfiguration()).thenReturn(serverConfiguration);
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("context-path-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpSession session = mock(HttpSession.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getSession()).thenReturn(session);
+        when(request.getContextPath()).thenReturn("/jenkins");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, request, response));
+
+        verify(session).invalidate();
+        verify(response).sendRedirect("/jenkins/securityRealm/commenceLogin");
     }
 
     @Test
@@ -298,6 +396,40 @@ public class OicSecurityRealmTokenExpirationTest {
     }
 
     @Test
+    void isNonInteractiveRequest_recognizesEachSupportedRequestSignal() {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+
+        assertFalse(realm.isNonInteractiveRequest(null));
+
+        HttpServletRequest xhr = mock(HttpServletRequest.class);
+        when(xhr.getHeader("X-Requested-With")).thenReturn("xmlhttprequest");
+        assertTrue(realm.isNonInteractiveRequest(xhr));
+
+        HttpServletRequest fetch = mock(HttpServletRequest.class);
+        when(fetch.getHeader("Sec-Fetch-Dest")).thenReturn("empty");
+        assertTrue(realm.isNonInteractiveRequest(fetch));
+
+        HttpServletRequest api = mock(HttpServletRequest.class);
+        when(api.getHeader("Accept")).thenReturn("application/json");
+        assertTrue(realm.isNonInteractiveRequest(api));
+
+        HttpServletRequest ajaxPath = mock(HttpServletRequest.class);
+        when(ajaxPath.getRequestURI()).thenReturn("/widget/ExecutorWidget/ajax");
+        assertTrue(realm.isNonInteractiveRequest(ajaxPath));
+
+        HttpServletRequest crumb = mock(HttpServletRequest.class);
+        when(crumb.getHeader("Jenkins-Crumb")).thenReturn("crumb");
+        assertTrue(realm.isNonInteractiveRequest(crumb));
+
+        HttpServletRequest navigation = mock(HttpServletRequest.class);
+        when(navigation.getHeader("Sec-Fetch-Dest")).thenReturn("document");
+        when(navigation.getHeader("Accept")).thenReturn("text/html,application/xhtml+xml");
+        when(navigation.getRequestURI()).thenReturn("/job/example/");
+        assertFalse(realm.isNonInteractiveRequest(navigation));
+    }
+
+    @Test
     void expireCredentials_replacesCredentialsWithExpiredEmptyTokens() throws Exception {
         OicSecurityRealm realm = mock(OicSecurityRealm.class);
         doCallRealMethod().when(realm).expireCredentials(anyString());
@@ -320,5 +452,17 @@ public class OicSecurityRealmTokenExpirationTest {
         assertFalse(expiredCredentials.getRefreshToken() != null
                 && !expiredCredentials.getRefreshToken().isEmpty());
         assertTrue(expiredCredentials.getExpiresAtMillis() <= Clock.systemUTC().millis());
+    }
+
+    @Test
+    void expireCredentials_ignoresMissingUser() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        doCallRealMethod().when(realm).expireCredentials(anyString());
+
+        try (MockedStatic<User> userMocked = mockStatic(User.class)) {
+            userMocked.when(() -> User.getById("missing-user", false)).thenReturn(null);
+
+            realm.expireCredentials("missing-user");
+        }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/OicSecurityRealmTokenExpirationTest.java
@@ -363,6 +363,92 @@ public class OicSecurityRealmTokenExpirationTest {
     }
 
     @Test
+    void handleExpiredToken_redirectsWhenRequestIsNull() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+        when(realm.getLoginUrl()).thenReturn("securityRealm/commenceLogin");
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("null-request-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, null, response));
+
+        verify(response).sendRedirect("/securityRealm/commenceLogin");
+    }
+
+    @Test
+    void handleExpiredToken_withoutExistingSessionInvalidatesCreatedSession() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+        when(realm.getLoginUrl()).thenReturn("/securityRealm/commenceLogin");
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
+        when(expiredCredentials.getRefreshToken()).thenReturn("refresh-token");
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("new-session-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpSession session = mock(HttpSession.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(null);
+        when(request.getSession()).thenReturn(session);
+        when(request.getContextPath()).thenReturn("");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, request, response));
+
+        verify(session).invalidate();
+        verify(response).sendRedirect("/securityRealm/commenceLogin");
+    }
+
+    @Test
+    void handleExpiredToken_withAuthorizationHeaderDoesNotInvalidateSession() throws Exception {
+        OicSecurityRealm realm = mock(OicSecurityRealm.class);
+        when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
+        when(realm.isNonInteractiveRequest(any())).thenCallRealMethod();
+        when(realm.isExpired(any())).thenCallRealMethod();
+        when(realm.canRefreshToken(any())).thenReturn(false);
+        when(realm.isTokenExpirationCheckDisabled()).thenReturn(false);
+        when(realm.getLoginUrl()).thenReturn("/securityRealm/commenceLogin");
+
+        OicCredentials expiredCredentials = mock(OicCredentials.class);
+        when(expiredCredentials.getExpiresAtMillis())
+                .thenReturn(Clock.systemUTC().millis() - 10);
+        User user = mock(User.class);
+        when(user.getId()).thenReturn("authorization-header-user");
+        when(user.getProperty(OicCredentials.class)).thenReturn(expiredCredentials);
+
+        HttpSession session = mock(HttpSession.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(null);
+        when(request.getSession()).thenReturn(session);
+        when(request.getHeader("Authorization")).thenReturn("Bearer token");
+        when(request.getContextPath()).thenReturn("");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertFalse(realm.handleExpiredToken(user, request, response));
+
+        verify(session, never()).invalidate();
+        verify(response).sendRedirect("/securityRealm/commenceLogin");
+    }
+
+    @Test
     void handleExpiredToken_nonInteractiveRequestReturnsUnauthorizedInsteadOfRedirect() throws Exception {
         OicSecurityRealm realm = mock(OicSecurityRealm.class);
         when(realm.handleExpiredToken(any(), any(), any())).thenCallRealMethod();
@@ -427,6 +513,14 @@ public class OicSecurityRealmTokenExpirationTest {
         when(navigation.getHeader("Accept")).thenReturn("text/html,application/xhtml+xml");
         when(navigation.getRequestURI()).thenReturn("/job/example/");
         assertFalse(realm.isNonInteractiveRequest(navigation));
+
+        HttpServletRequest iframe = mock(HttpServletRequest.class);
+        when(iframe.getHeader("Sec-Fetch-Dest")).thenReturn("iframe");
+        assertFalse(realm.isNonInteractiveRequest(iframe));
+
+        HttpServletRequest xhtml = mock(HttpServletRequest.class);
+        when(xhtml.getHeader("Accept")).thenReturn("application/xhtml+xml");
+        assertFalse(realm.isNonInteractiveRequest(xhtml));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/oic/PluginTest.java
@@ -76,6 +76,7 @@ import javax.net.ssl.SSLException;
 import jenkins.model.Jenkins;
 import jenkins.security.LastGrantedAuthoritiesProperty;
 import org.htmlunit.CookieManager;
+import org.htmlunit.Page;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.Cookie;
 import org.jenkinsci.plugins.oic.plugintest.PluginTestHelper;
@@ -210,6 +211,39 @@ class PluginTest {
 
         String secondLoginSession = cookieManager.getCookie(cookieName).getValue();
         assertNotEquals(firstLoginSession, secondLoginSession, "The session should be renewed when the user log in");
+    }
+
+    @Test
+    void finishLoginWithMissingSessionStateRestartsLogin() throws Exception {
+        configureTestRealm(wireMock, jenkins, sc -> {});
+        webClient.getOptions().setRedirectEnabled(false);
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+        Page page = webClient.goTo("securityRealm/finishLogin?state=stale-state&code=unused-code", null);
+
+        assertEquals(302, page.getWebResponse().getStatusCode());
+        assertEquals(
+                jenkinsRule.contextPath + "/securityRealm/commenceLogin",
+                page.getWebResponse().getResponseHeaderValue("Location"));
+        assertAnonymous(webClient);
+        wireMock.verify(0, postRequestedFor(urlPathEqualTo("/token")));
+    }
+
+    @Test
+    void finishLoginWithMismatchedStateRestartsLogin() throws Exception {
+        configureTestRealm(wireMock, jenkins, sc -> {});
+        webClient.getOptions().setRedirectEnabled(false);
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+        webClient.goTo("securityRealm/commenceLogin", null);
+        Page page = webClient.goTo("securityRealm/finishLogin?state=stale-state&code=unused-code", null);
+
+        assertEquals(302, page.getWebResponse().getStatusCode());
+        assertEquals(
+                jenkinsRule.contextPath + "/securityRealm/commenceLogin",
+                page.getWebResponse().getResponseHeaderValue("Location"));
+        assertAnonymous(webClient);
+        wireMock.verify(0, postRequestedFor(urlPathEqualTo("/token")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Harden the expired OIDC token path so concurrent Jenkins requests do not
trigger refresh storms or redirect AJAX calls into an interactive login, and
restart login safely when an old callback arrives with missing or mismatched
session state.

This supersedes the closed #748 and preserves @scheremisin's authorship on the
rebased refresh-hardening commit. It also incorporates the focused behavior
discussed in #753 and adds callback-state recovery observed while reproducing
the same failure family.

Related reports and proposals: #411, #467, #706, #748, #753.

## Changes

- Serialize refresh per Jenkins user and re-read credentials after acquiring
  the lock, so rotated refresh tokens are not reused concurrently.
- Attempt refresh when a stored refresh token exists and discovery metadata
  omits the optional `grant_types_supported` field.
- Return `401 Unauthorized` to AJAX and other non-interactive requests instead
  of redirecting them into the OIDC authorization flow.
- Use a Jenkins context-relative, root-based URL for interactive login
  redirects.
- Clear stored credentials after an `invalid_grant` refresh response so polling
  requests do not retry a known-invalid refresh token.
- Restart interactive login when the callback has missing or mismatched OIDC
  session state, without calling the token endpoint.
- Add focused concurrency, fallback, invalid-token, redirect, and callback-state
  tests.

## Why this is needed

Jenkins pages routinely issue several concurrent widget and AJAX requests. If
the access token expires while the Jenkins HTTP session remains valid, all of
those requests can observe the same credentials. Providers that rotate refresh
tokens may accept the first refresh and reject the others with
`invalid_grant`. If refresh is unavailable, redirecting an AJAX request to the
authorization endpoint can also produce CORS errors, stale crumbs, nested-path
login URLs, and multiple overlapping callbacks.

OIDC discovery defines `grant_types_supported` as optional. Its absence should
not override the stronger runtime signal that the provider already issued a
refresh token.

## Testing done

```text
mvn verify
Tests run: 172, Failures: 0, Errors: 0, Skipped: 2
Checkstyle violations: 0
SpotBugs errors/warnings: 0
Spotless: clean
BUILD SUCCESS
```

The new tests execute:

- refresh capability with absent and explicit grant-type metadata;
- same-user concurrent refresh;
- interactive and non-interactive fallback behavior;
- invalid refresh credential cleanup;
- callback recovery for missing and mismatched session state.

### Submitter checklist

- [x] Opened from a topic branch
- [x] PR title represents the desired changelog entry
- [x] Described the behavior and compatibility impact
- [x] Linked relevant issues and prior pull requests
- [x] Added automated tests that execute the changed paths
