### PR TITLE
Migrate commons-lang2 to lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     -->
     <pac4jVersion>6.4.3</pac4jVersion>
     <hpi.bundledArtifacts>content-type,jmespath-core,lang-tag,oauth2-oidc-sdk,pac4j-core,pac4j-jakartaee,pac4j-oidc,protobuf-java,tink</hpi.bundledArtifacts>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/org/jenkinsci/plugins/oic/properties/DisableTokenVerification.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/properties/DisableTokenVerification.java
@@ -4,7 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import java.io.Serial;
 import jenkins.security.FIPS140;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.jenkinsci.plugins.oic.AnythingGoesTokenValidator;
 import org.jenkinsci.plugins.oic.OicServerConfiguration;
 import org.jenkinsci.plugins.oic.OidcProperty;

--- a/src/main/java/org/jenkinsci/plugins/oic/properties/EscapeHatch.java
+++ b/src/main/java/org/jenkinsci/plugins/oic/properties/EscapeHatch.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.oic.properties;
 
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;


### PR DESCRIPTION
Prepare for https://github.com/jenkinsci/jenkins/pull/26105 by removing lang2 usages.
lang3-api is already a dependency here, so just migrate the import to there https://github.com/jenkinsci/oic-auth-plugin/blob/f202e4229f6139f22087980abe5a07fdc857ec53/pom.xml#L97-L100

### Testing done

* compilation successful with a local jenkins without having lang2 in it - `mvn clean compile -Djenkins.version=2.574-SNAPSHOT`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed